### PR TITLE
docs: make the documentation site true for 0.5.0 and guard it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/build/
 
 # PyBuilder
 .pybuilder/
@@ -189,3 +190,6 @@ cython_debug/
 
 # Ignore Cargo.lock for Rust library
 **/Cargo.lock
+
+# Agents
+CLAUDE.local.md

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ import os
 project = 'zeusdb'
 copyright = '2025, ZeusDB'
 author = 'ZeusDB'
-release = '0.0.8'
+release = '0.1.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -6,29 +6,33 @@ orphan: true
 
 # Installation
 
-You can install ZeusDB Vector Database with 'uv' or alternatively using 'pip'.
+You can install ZeusDB with 'uv' or alternatively using 'pip'.
 
 
 Recommended (with uv):
-```python
+```bash
 uv pip install zeusdb
 ```
 
 Alternatively (just with pip):
-```{code-block} python
+```bash
 pip install zeusdb
 ```
 
 <br />
 
 ## Python version support
-Officially Python 3.10, 3.11, 3.12 and 3.13.
+Officially Python 3.10, 3.11, 3.12, 3.13 and 3.14.
 
 <br /> 
 
 ## Dependencies
 
-| Package | Minimum required version |
+Installing `zeusdb` brings in the vector database and its dependencies automatically.
+
+| Package | Version installed |
 |---------|---------------------------|
-| [NumPy](https://numpy.org/) | 2.2.6 |
-| [zeusdb-vector-database](https://github.com/ZeusDB/zeusdb-vector-database) | 0.4.1 |
+| [zeusdb-vector-database](https://github.com/ZeusDB/zeusdb-vector-database) | 0.5.x (`>=0.5.0,<0.6.0`) |
+| [NumPy](https://numpy.org/) | `>=2.2.6,<3.0.0` (required by the vector database) |
+
+Prebuilt wheels are published for Linux x86_64 and aarch64 (glibc and musl), macOS Apple Silicon, and Windows x86_64.

--- a/docs/source/vector_database/getting_started.md
+++ b/docs/source/vector_database/getting_started.md
@@ -4,15 +4,15 @@ This guide will help you get up and running quickly with high-performance vector
 
 ## 📦 Installation
 
-You can install ZeusDB Vector Database with 'uv' or alternatively using 'pip'.
+You can install ZeusDB with 'uv' or alternatively using 'pip'.
 
 Recommended (with uv):
-```python
+```bash
 uv pip install zeusdb
 ```
 
 Alternatively (just with pip):
-```{code-block} python
+```bash
 pip install zeusdb
 ```
 
@@ -44,32 +44,24 @@ records = [
 
 # Upload records using the `add()` method
 add_result = index.add(records)
-print("\n--- Add Results Summary ---")
 print(add_result.summary())
 
 # Perform a similarity search and print the top 2 results
-# Query Vector
 query_vector = [0.1, 0.2, 0.3, 0.1, 0.4, 0.2, 0.6, 0.7]
 
-# Query with no filter (all documents)
 results = index.search(vector=query_vector, filter=None, top_k=2)
-print("\n--- Query Results Output - Raw ---")
-print(results)
 
-print("\n--- Query Results Output - Formatted ---")
 for i, res in enumerate(results, 1):
-    print(f"{i}. ID: {res['id']}, Score: {res['score']:.4f}, Metadata: {res['metadata']}")
+    print(f"{i}. ID: {res['id']}, Score: {res['score']:.6f}, Metadata: {res['metadata']}")
 ```
 
 *Results Output:*
 ```text
---- Add Results Summary ---
-✅ 5 inserted, ❌ 0 errors
-
---- Raw Results Format ---
-[{'id': 'doc_001', 'score': 0.0, 'metadata': {'author': 'Alice'}}, {'id': 'doc_003', 'score': 0.0009883458260446787, 'metadata': {'author': 'Alice'}}]
-
---- Formatted Results ---
-1. ID: doc_001, Score: 0.0000, Metadata: {'author': 'Alice'}
-2. ID: doc_003, Score: 0.0010, Metadata: {'author': 'Alice'}
+5 inserted, 0 errors
+1. ID: doc_001, Score: 0.000000, Metadata: {'author': 'Alice'}
+2. ID: doc_003, Score: 0.000988, Metadata: {'author': 'Alice'}
 ```
+
+`add_result.summary()` returns a plain ASCII string, so it prints on any console encoding. The same counts are on `add_result.total_inserted` and `add_result.total_errors` if you want the numbers rather than the sentence.
+
+Scores are distances, so lower means more similar. A vector identical to the query scores 0.0, or a value within floating point error of it.

--- a/docs/source/vector_database/index.md
+++ b/docs/source/vector_database/index.md
@@ -16,7 +16,7 @@ Whether you're powering document search, enabling natural language interfaces, o
 
 🔍 Approximate Nearest Neighbor (ANN) search using HNSW for lightning fast results
 
-📦 Product Quantization (PQ) for compact storage, faster distance computations, and scalability for Big Data
+📦 Product Quantization (PQ) for compact storage, with reranking to hold accuracy
 
 📥 Flexible input formats, including native Python types and NumPy arrays
 
@@ -34,7 +34,7 @@ ZeusDB Vector Database supports the following metrics for vector similarity sear
 
 | Metric | Description                          | Accepted Values (case-insensitive)  |
 |--------|--------------------------------------|--------|
-| cosine | Cosine Distance (1 - Cosine Similiarity) | "cosine", "COSINE", "Cosine" |
+| cosine | Cosine Distance (1 - Cosine Similarity) | "cosine", "COSINE", "Cosine" |
 | l1     | Manhattan distance                   | "l1", "L1" |
 | l2     | Euclidean distance                 | "l2", "L2" |
 
@@ -44,9 +44,13 @@ ZeusDB Vector Database supports the following metrics for vector similarity sear
 All distance metrics in ZeusDB Vector Database return distance values, not similarity scores:
 
  - Lower values = more similar
- - A score of 0.0 means a perfect match
+ - A vector identical to the query scores 0.0, or a value within floating point error of it
 
 This applies to all distance types, including cosine.
+
+Under `cosine`, vectors are normalized to unit length when they are stored. A vector you read back with `return_vector=True` or `get_records()` is therefore the normalized form, not the values you supplied. Under `l1` and `l2` the values are stored unchanged.
+
+A zero vector has no direction, so under `cosine` it sits at distance 1.0 from everything, including itself.
 
 
 
@@ -65,4 +69,6 @@ persistence
 metadata_filtering
 utilities
 logging
+upgrading
 integrations/index
+```

--- a/docs/source/vector_database/integrations/index.md
+++ b/docs/source/vector_database/integrations/index.md
@@ -2,13 +2,15 @@
 
 A hub for using ZeusDB with popular AI frameworks and tools.
 
-- ✅ **LangChain** — VectorStore implementation with similarity/MMR search, metadata filtering, quantization, persistence, and async support.  
-- 🧭 Roadmap: **LlamaIndex**, **OpenAI**, **Hugging Face**, and more.
+- ✅ **LangChain**: VectorStore implementation with similarity/MMR search, metadata filtering, quantization, persistence, and async support.  
+- ✅ **LlamaIndex**: VectorStore implementation with direct query interface, MMR search, metadata filtering, quantization, persistence, and async support.  
+- 🧭 Roadmap: **OpenAI**, **Hugging Face**, and more.
 
 ## Compatibility
 | Integration | Package Name | Minimum ZeusDB | Framework Version | Status |
 |---|---|---|---|---|
-| LangChain | `langchain-zeusdb` | `zeusdb>=0.0.8` | `langchain-core>=0.3.74` | ✅ Stable |
+| LangChain | `langchain-zeusdb` | `zeusdb>=0.0.8` | `langchain-core>=0.3.74,<0.4` | ✅ Stable |
+| LlamaIndex | `llama-index-vector-stores-zeusdb` | `zeusdb>=0.0.8` | `llama-index-core>=0.14.6` | ✅ Stable |
 
 
 ## Contribute / Request
@@ -19,10 +21,10 @@ Open a request on GitHub Issues or submit a PR to add an integration guide.
 
 
 
-
 ```{toctree}
 :maxdepth: 1
 :hidden:
 
 langchain
 llamaindex
+```

--- a/docs/source/vector_database/integrations/langchain.md
+++ b/docs/source/vector_database/integrations/langchain.md
@@ -6,8 +6,8 @@ A high-performance LangChain integration for ZeusDB, bringing enterprise-grade v
 
 🚀 **High Performance**
 - Rust-powered vector database backend
-- Advanced HNSW indexing for sub-millisecond search
-- Product Quantization for 4x-256x memory compression
+- Advanced HNSW indexing for fast approximate nearest neighbor search
+- Product Quantization for memory compression, with reranking to hold accuracy
 - Concurrent search with automatic parallelization
 
 🎯 **LangChain Native**
@@ -164,9 +164,8 @@ For large datasets, use Product Quantization to reduce memory usage:
 # Create quantized index for memory efficiency
 quantization_config = {
     'type': 'pq',
-    'subvectors': 8,
-    'bits': 8,
-    'training_size': 10000
+    'training_size': 10000,
+    'storage_mode': 'quantized_with_raw'  # Keep raw vectors so search can rerank
 }
 
 vdb = VectorDatabase()
@@ -174,6 +173,7 @@ index = vdb.create(
     index_type="hnsw",
     dim=1536,
     space="cosine",
+    expected_size=50000,
     quantization_config=quantization_config
 )
 
@@ -183,7 +183,7 @@ vector_store = ZeusDBVectorStore(
 )
 ```
 
-Please refer to our [documentation](https://docs.zeusdb.com/en/latest/vector_database/product_quantization.html) for helpful configuration guidelines and recommendations for setting up quantization.
+`quantized_with_raw` lets search rerank against the raw vectors, which holds recall at the level of an unquantized index. The default `quantized_only` mode saves more memory and returns far fewer of the correct results. Please refer to our [documentation](https://docs.zeusdb.com/en/latest/vector_database/product_quantization.html) for configuration guidelines and the measured trade-offs.
 
 <br />
 
@@ -221,7 +221,7 @@ print("store peek:", loaded_store.zeusdb_index.list(2))
 **Notes**
  - The path is a directory, not a single file. Ensure the target is writable.
  - Saved indexes are cross-platform and include format/version info for compatibility checks.
- - If you used PQ, both the compression model and state are preserved—no need to retrain after loading.
+ - If you used PQ, both the compression model and state are preserved, so there is no need to retrain after loading.
  - You can continue to use all vector store APIs (similarity_search, retrievers, etc.) on the loaded_store.
 
 For further details (including file structure, and further comprehensive examples), see the [documentation](https://docs.zeusdb.com/en/latest/vector_database/persistence.html).
@@ -234,7 +234,7 @@ Use these to control scoring, diversity, metadata filtering, and retriever integ
 
 #### Similarity search with scores
 
-Returns `(Document, raw_distance)` pairs from ZeusDB — **lower distance = more similar**.  
+Returns `(Document, raw_distance)` pairs from ZeusDB, where **lower distance = more similar**.  
 If you prefer normalized relevance in `[0, 1]`, use `similarity_search_with_relevance_scores`.
 
 ```python
@@ -499,7 +499,7 @@ import logging
 
 # Operations are automatically logged with performance metrics
 vector_store.add_documents(docs)
-# Logs: {"operation":"vector_addition","total_inserted":2,"duration_ms":45}
+# Logs: {"operation":"add_vectors_complete","total_inserted":2,"total_errors":0,"duration_ms":45}
 
 # Control logging with environment variables if needed
 # ZEUSDB_LOG_LEVEL=debug ZEUSDB_LOG_FORMAT=json python your_app.py
@@ -553,9 +553,11 @@ except Exception as e:
 
 ## Requirements
 
-- **Python**: 3.10 or higher
-- **ZeusDB**: 0.0.8 or higher
-- **LangChain Core**: 0.3.74 or higher
+`langchain-zeusdb` declares the following, and these are the constraints an install resolves against.
+
+- **Python**: `>=3.10`
+- **ZeusDB**: `zeusdb>=0.0.8`
+- **LangChain Core**: `langchain-core>=0.3.74,<0.4`
 
 ## Installation from Source
 
@@ -572,8 +574,8 @@ In internal benchmarks, ZeusDB has demonstrated exceptional performance for larg
 | Operation | Performance | Notes |
 |-----------|-------------|-------|
 | Index Creation | 1M+ vectors/min | Depends on vector dimension |
-| Search Latency | <1ms | Sub-millisecond for most queries |
-| Memory Usage | 50-90% reduction | With Product Quantization |
+| Search Latency | <1ms | Small unquantized indexes; grows with corpus size |
+| Memory Usage | Up to 78% reduction | Measured with Product Quantization at 50,000 records of dim 1536; varies with dimension and storage mode |
 | Concurrent QPS | 10,000+ | Multi-threaded search |
 
 ⚠️ Note: These figures represent internal benchmark results under specific test conditions. Actual performance may vary depending on hardware, vector dimensions, dataset size, and workload characteristics.
@@ -588,11 +590,8 @@ In internal benchmarks, ZeusDB has demonstrated exceptional performance for larg
 
 ## Compatibility
 
-### LangChain Versions
-- **LangChain Core**: 0.3.74+
-
 ### Distance Metrics
-- **Cosine**: Default, normalized similarity
+- **Cosine**: Default; vectors are normalized when stored, scores are distances
 - **Euclidean (L2)**: Geometric distance
 - **Manhattan (L1)**: City-block distance
 

--- a/docs/source/vector_database/integrations/llamaindex.md
+++ b/docs/source/vector_database/integrations/llamaindex.md
@@ -14,8 +14,8 @@ A high-performance LlamaIndex integration for ZeusDB, bringing enterprise-grade 
 🚀 **High Performance**
 
 - Rust-powered vector database backend
-- Advanced HNSW indexing for sub-millisecond search
-- Product Quantization for 4x-256x memory compression
+- Advanced HNSW indexing for fast approximate nearest neighbor search
+- Product Quantization for memory compression, with reranking to hold accuracy
 - Concurrent search with automatic parallelization
 
 🏢 **Enterprise Ready**
@@ -262,7 +262,7 @@ print(f"   Vector count: {loaded_store.get_vector_count()}")
 
 - The path is a directory, not a single file. Ensure the target is writable.
 - Saved indexes are cross-platform and include format/version info for compatibility checks.
-- If you used PQ, both the compression model and state are preserved—no need to retrain after loading.
+- If you used PQ, both the compression model and state are preserved, so there is no need to retrain after loading.
 
 ### Memory-Efficient Setup with Quantization
 
@@ -467,7 +467,7 @@ else:
 Key stats: vectors=3, space=cosine
 Vector count: 3
 Index info: HNSWIndex(dim=1536, space=cosine, m=16, ef_construction=200, expected_size=10000, vectors=3, quantization=none)
-Is quantized: False
+Index is not quantized
 ```
 
 ### Enterprise Logging
@@ -540,9 +540,11 @@ except Exception as e:
 
 ## Requirements
 
-- **Python**: 3.10 or higher
-- **ZeusDB**: 0.0.8 or higher
-- **LlamaIndex Core**: 0.14.4 or higher
+`llama-index-vector-stores-zeusdb` declares the following, and these are the constraints an install resolves against.
+
+- **Python**: `>=3.10,<4.0`
+- **ZeusDB**: `zeusdb>=0.0.8`
+- **LlamaIndex Core**: `llama-index-core>=0.14.6`
 
 ## Installation from Source
 

--- a/docs/source/vector_database/logging.md
+++ b/docs/source/vector_database/logging.md
@@ -8,6 +8,7 @@ The logging system is designed to be invisible when you don’t need it and powe
 
 For most users, logging works automatically out of the box. No need to do anything.
 
+<!-- zeusdb:skip -->
 ```python
 from zeusdb import VectorDatabase
 # Logging is automatically configured - no setup required!
@@ -16,100 +17,56 @@ vdb = VectorDatabase()
 index = vdb.create("hnsw", dim=1536)
 
 # Operations are automatically logged with structured data
-result = index.add({"vectors": vectors, "ids": ids})
+result = index.add({"ids": ids, "embeddings": vectors})
 results = index.search(query_vector, top_k=5)
 ```
 
 **What you get automatically:**
-- ✅ **Silent by default** - Only errors and warnings in production
-- ✅ **Environment detection** - Appropriate defaults for dev/prod/testing
+- ✅ **Quiet by default** - Only errors and warnings outside development
+- ✅ **Environment detection** - Appropriate defaults for dev/prod/testing/CI/notebooks
 - ✅ **Structured JSON logs** in production environments  
 - ✅ **Human-readable logs** in development environments
-- ✅ **Performance timing** on all operations
+- ✅ **Operation timing** on index creation, additions, searches and saves
 - ✅ **Cross-platform compatibility** 
+
+Note that `save()` and `load()` print progress directly to stdout. That output is not part of the logging system and is not affected by any of the settings below.
 
 
 ### Smart Environment Detection
 
-This amazing feature automatically detects where your code is running and applies appropriate logging defaults!
+The system automatically detects where your code is running and applies appropriate logging defaults.
 
 - **🏭 Production** (`ENVIRONMENT=production`): ERROR level, JSON format, often file output
-- **💻 Development** (`ENVIRONMENT=development`): WARNING level, human format, console output  
+- **💻 Development** (default): WARNING level, human format, console output  
 - **🧪 Testing** (`pytest`, `PYTEST_CURRENT_TEST`): CRITICAL level, minimal output
 - **📓 Jupyter** (`JUPYTER_SERVER_ROOT`): INFO level, human format, clean output
 - **🔄 CI/CD** (`CI`, `GITHUB_ACTIONS`): WARNING level, human format for readability
 
 #### How Environment Detection Works
 
-The system automatically checks for these indicators:
+The system checks for these indicators, with an explicit `ENVIRONMENT` value winning over auto-detection:
 
 | Environment | Detection Method | What It Finds |
 |-------------|------------------|---------------|
+| **Explicit** | `ENVIRONMENT=production` / `development` / `testing` | User explicitly set (short forms `prod`, `dev`, `test` also accepted) |
 | **Testing** | `PYTEST_CURRENT_TEST` | pytest automatically sets this |
 | **Testing** | `'pytest' in sys.modules` | pytest imported |
 | **Jupyter** | `JUPYTER_SERVER_ROOT` | Jupyter server running |
 | **Jupyter** | `JPY_PARENT_PID` | Jupyter kernel process |
 | **Jupyter** | `'IPython' in sys.modules` | IPython/Jupyter imported |
-| **CI/CD** | `CI=true` | Most CI systems set this |
-| **CI/CD** | `GITHUB_ACTIONS=true` | GitHub Actions |
-| **CI/CD** | `GITLAB_CI=true` | GitLab CI |
+| **CI/CD** | `CI` | Most CI systems set this |
+| **CI/CD** | `GITHUB_ACTIONS` | GitHub Actions |
+| **CI/CD** | `GITLAB_CI` | GitLab CI |
 | **Production** | `KUBERNETES_SERVICE_HOST` | Running in Kubernetes |
 | **Production** | `DOCKER_CONTAINER` | Running in Docker |
-| **Explicit** | `ENVIRONMENT=production` | User explicitly set |
 
-#### Real-World Examples
-
-**🧪 In pytest:**
-```bash
-$ pytest test_my_app.py
-# Environment detected: 'testing'
-# Applied: CRITICAL level, no console output, minimal format
-# Result: Your tests run clean without log spam!
-```
-
-**📓 In Jupyter:**
-```python
-# Cell 1
-import zeusdb
-# Environment detected: 'jupyter' (via JUPYTER_SERVER_ROOT)
-# Applied: INFO level, human format, clean timestamps
-# Result: Nice readable logs for exploration!
-
-# Cell 2  
-vdb = zeusdb.VectorDatabase()
-# Logs: "Index created: dim=1536, vectors=0" (clean, readable)
-```
-
-**🏭 In Docker production:**
-```bash
-$ docker run my-app
-# Environment detected: 'production' (via KUBERNETES_SERVICE_HOST)
-# Applied: ERROR level, JSON format, structured output
-# Result: Production-ready structured logs!
-```
-
-**💻 On your laptop:**
-```bash
-$ python my_script.py
-# Environment detected: 'development' (default)
-# Applied: WARNING level, human format, console output
-# Result: Clean development experience!
-```
-
-#### Test Environment Detection Yourself
-
-```python
-# See what environment is detected
-import zeusdb.logging_config as lc
-env = lc._detect_environment()
-print(f"Detected environment: {env}")
-
-config = lc._get_smart_defaults(env)
-print(f"Applied config: {config}")
-```
+Environment variables always override the detected defaults.
 
 #### Override Environment Detection
 
+Set `ENVIRONMENT` before ZeusDB is first imported, since the defaults are applied at import time:
+
+<!-- zeusdb:skip -->
 ```python
 import os
 
@@ -143,29 +100,22 @@ export ZEUSDB_LOG_FILE=/var/log/zeusdb/app.log
 python your_app.py
 ```
 
-**Machine Learning Pipeline Debugging**
-```bash
-# For ML workflows where you want detailed progress tracking
-export ZEUSDB_LOG_LEVEL=info
-export ZEUSDB_LOG_FORMAT=human
-export ZEUSDB_LOG_CONSOLE=true
-python train_embeddings.py
-
-# Example output you'll see:
-# 2025-01-15 14:30:15 - INFO - Starting PQ training: 5000 vectors
-# 2025-01-15 14:30:19 - INFO - PQ training completed: 4.2s (compression: 192x)
-# 2025-01-15 14:30:20 - INFO - Vector addition completed: 10000 vectors in 2.1s
-```
-
 ### Environment Variables Reference
 
 | Variable | Options | Default | Description |
 |----------|---------|---------|-------------|
-| `ZEUSDB_LOG_LEVEL` | `trace`, `debug`, `info`, `warning`, `error`, `critical` | `warning` (dev), `error` (prod) | Controls log verbosity |
+| `ZEUSDB_LOG_LEVEL` | `trace`, `debug`, `info`, `error` | `warning` (dev), `error` (prod) | Controls log verbosity |
 | `ZEUSDB_LOG_FORMAT` | `human`, `json` | `human` (dev), `json` (prod) | Output format |
 | `ZEUSDB_LOG_TARGET` | `stdout`, `stderr`, `file` | `stderr` | Where logs go |
-| `ZEUSDB_LOG_FILE` | `/path/to/file.log` | `zeusdb.log` | Log file path (if target=file) |
+| `ZEUSDB_LOG_FILE` | `/path/to/file.log` | `zeusdb.log` | Log file path, written exactly as given (if target=file) |
+| `ZEUSDB_LOG_ROTATION` | `daily`, `never` | `never` | With `daily`, a UTC date is appended to the file name |
 | `ZEUSDB_LOG_CONSOLE` | `true`, `false` | Auto-detected | Force console output |
+| `ZEUSDB_DISABLE_AUTO_LOGGING` | `true`, `1`, `yes` | unset | Skip automatic configuration entirely |
+| `RUST_LOG` | standard `env_logger` syntax | unset | Overrides `ZEUSDB_LOG_LEVEL` for the Rust layer |
+
+**⚠️ `warning` and `critical` are not accepted level names.** The Python layer accepts them, but the Rust layer rejects them and prints `ignoring 'zeusdb_vector_database=warning': invalid filter directive`. The bare `warn` is the opposite, accepted by Rust and rejected by Python. Use `trace`, `debug`, `info` or `error`, which both layers accept.
+
+**Log rotation.** `ZEUSDB_LOG_FILE` writes exactly the path given. Under `ZEUSDB_LOG_ROTATION=daily` with `ZEUSDB_LOG_FILE=logs/app.log`, two files appear: `logs/app.log` and a dated `logs/app.log.2026-08-05`. Rotation applies to the Rust layer, which writes the dated one.
 
 <br />
 
@@ -174,6 +124,7 @@ python train_embeddings.py
 For enterprise environments with existing logging infrastructure.
 
 ### Option 1: Disable Auto-Configuration
+<!-- zeusdb:skip -->
 ```python
 import os
 os.environ["ZEUSDB_DISABLE_AUTO_LOGGING"] = "1"
@@ -182,31 +133,36 @@ os.environ["ZEUSDB_DISABLE_AUTO_LOGGING"] = "1"
 import logging
 logging.basicConfig(level=logging.INFO, format='%(message)s')
 
-from zeusdb_vector_database import VectorDatabase  # Will respect your existing logging setup
+from zeusdb import VectorDatabase  # Will respect your existing logging setup
 ```
 
 ### Option 2: Programmatic Initialization
+<!-- zeusdb:skip -->
 ```python
 import os
 os.environ["ZEUSDB_DISABLE_AUTO_LOGGING"] = "1"
 
 import zeusdb
 
-# Initialize with JSON to console 
+# JSON to stdout
 success = zeusdb.init_logging(level="info")
 
-# OR initialize with file logging
-success = zeusdb.init_file_logging(
-    log_dir="/var/log/myapp",
-    level="debug", 
-    file_prefix="zeusdb"
-)
+# OR JSON to a directory of daily rotating files. Pick one, not both.
+# success = zeusdb.init_file_logging(
+#     log_dir="/var/log/myapp",
+#     level="debug", 
+#     file_prefix="zeusdb"
+# )
 
-# Then use normally
+print("initialized:", success)
+
 vdb = zeusdb.VectorDatabase()
 ```
 
+**Only the first initializer to run takes effect.** Both functions return `True` if they installed the logging subscriber and `False` if one was already installed, so calling both leaves the second with no effect and a `False` return. `zeusdb.is_logging_initialized()` reports whether either has run.
+
 ### Option 3: Custom Logger Integration
+<!-- zeusdb:skip -->
 ```python
 import logging
 import os
@@ -229,38 +185,35 @@ from zeusdb import VectorDatabase
 ### 📊 Log Output Examples
 
 #### Human-Readable (Development)
-```
-2025-01-15 10:30:15 - zeusdb.vector - INFO - Index created: dim=1536, vectors=0
-2025-01-15 10:30:16 - zeusdb.vector - INFO - Added 1000 vectors in 45ms
-2025-01-15 10:30:16 - zeusdb.vector - DEBUG - Search completed: 5 results in 2ms
+```text
+2026-08-05T12:19:39.261318Z  INFO build: HNSW index created successfully operation="index_creation_complete" dim=8 space=cosine m=16 ef_construction=200 expected_size=10000 has_quantization=false duration_ms=0
+2026-08-05T12:19:39.3491294Z  INFO add: Vector addition completed operation="add_vectors_complete" total_inserted=2 total_errors=0 success_rate=100.0 duration_ms=87 overwrite_mode=true final_storage_mode="raw_only"
 ```
 
 #### Structured JSON (Production)
 ```json
-{"timestamp":"2025-01-15T10:30:15.123Z","level":"INFO","operation":"index_creation","dim":1536,"space":"cosine","duration_ms":12}
-{"timestamp":"2025-01-15T10:30:16.456Z","level":"INFO","operation":"vector_addition","total_inserted":1000,"duration_ms":45}
-{"timestamp":"2025-01-15T10:30:16.789Z","level":"DEBUG","operation":"search_complete","results_count":5,"duration_ms":2}
+{"timestamp":"2026-08-05T12:19:39.4853862Z","level":"INFO","fields":{"message":"HNSW index created successfully","operation":"index_creation_complete","dim":8,"space":"cosine","m":16,"ef_construction":200,"expected_size":10000,"has_quantization":false,"duration_ms":"0"},"target":"zeusdb_vector_database::hnsw_index","filename":"src\\hnsw_index.rs","line_number":1068,"threadId":"ThreadId(1)"}
 ```
 
 ### 🔍 Monitoring and Observability
 
-#### Key Metrics to Monitor
-- **`operation`**: Type of operation (index_creation, vector_addition, search, etc.)
-- **`duration_ms`**: Performance timing for all operations
-- **`total_inserted`**, **`total_errors`**: Success/failure rates
-- **`compression_ratio`**: Memory efficiency with quantization
-- **`training_progress`**: Quantization training status
+#### Key Fields to Monitor
+- **`operation`**: the operation name, for example `index_creation_complete`, `add_vectors_complete`, `search_complete`, `pq_training_complete`, `save_complete`, `compact_complete`
+- **`duration_ms`**: timing on index creation, additions, searches, saves and compaction
+- **`total_inserted`**, **`total_errors`**, **`success_rate`**: outcome of each `add()`
+- **`final_storage_mode`**: whether an index is serving raw or quantized results
+- **`results_count`**: results returned by a search
 
 #### Production Alerting Examples
 ```bash
 # Monitor error rates
 grep '"level":"ERROR"' /var/log/zeusdb/app.log | wc -l
 
-# Track performance degradation  
-grep '"operation":"search"' /var/log/zeusdb/app.log | jq '.duration_ms' | avg
+# Track search latency
+grep '"operation":"search_complete"' /var/log/zeusdb/app.log | jq '.fields.duration_ms'
 
 # Watch quantization training
-grep '"operation":"pq_training"' /var/log/zeusdb/app.log | tail -f
+grep '"operation":"pq_training' /var/log/zeusdb/app.log
 ```
 
 ### 🛠️ Troubleshooting
@@ -272,8 +225,8 @@ grep '"operation":"pq_training"' /var/log/zeusdb/app.log | tail -f
 # Check if auto-logging is disabled
 echo $ZEUSDB_DISABLE_AUTO_LOGGING
 
-# Verify log level
-ZEUSDB_LOG_LEVEL=debug python -c "import zeusdb; print('Logging active')"
+# Verify the level is one both layers accept
+ZEUSDB_LOG_LEVEL=debug python -c "import zeusdb; print(zeusdb.is_logging_initialized())"
 ```
 
 **File logging not working?**
@@ -291,10 +244,9 @@ ZEUSDB_LOG_TARGET=stderr ZEUSDB_LOG_LEVEL=info python your_app.py
 ZEUSDB_LOG_LEVEL=trace python your_app.py
 ```
 
-#### Performance Impact
-- **Minimal overhead**: Structured logging adds <1% performance impact
-- **Async file writing**: File logging doesn't block operations
-- **Smart buffering**: Logs are efficiently batched for performance
+#### Performance Notes
+- File logging is non-blocking: records are handed to a background writer rather than written on the calling thread.
+- `trace` and `debug` are verbose enough to dominate runtime on a hot loop. Leave production at `error`.
 
 ### Best Practices
 
@@ -310,6 +262,7 @@ export ZEUSDB_LOG_LEVEL=info
 export ZEUSDB_LOG_FORMAT=json
 export ZEUSDB_LOG_TARGET=file
 export ZEUSDB_LOG_FILE=logs/zeusdb-staging.log
+export ZEUSDB_LOG_ROTATION=daily
 ```
 
 #### Production
@@ -319,6 +272,7 @@ export ZEUSDB_LOG_LEVEL=error
 export ZEUSDB_LOG_FORMAT=json
 export ZEUSDB_LOG_TARGET=file
 export ZEUSDB_LOG_FILE=/var/log/zeusdb/production.log
+export ZEUSDB_LOG_ROTATION=daily
 ```
 
 Logging stays out of the way when you don’t need it, but delivers full power and flexibility when you do. Most users never need to touch the settings, while enterprise teams can fine-tune every aspect of observability.

--- a/docs/source/vector_database/metadata_filtering.md
+++ b/docs/source/vector_database/metadata_filtering.md
@@ -6,25 +6,29 @@ ZeusDB supports rich metadata with full type fidelity. This means your metadata 
 
 The following Python types are supported for metadata and preserved during filtering and retrieval.
 
-| Type | Python Example | Stored As | Notes |
-|------|----------------|-----------|-------|
-| **String** | `"Alice"` | `Value::String` | Text data, IDs, categories |
-| **Integer** | `42`, `2024` | `Value::Number` | Counts, years, IDs |
-| **Float** | `4.5`, `29.99` | `Value::Number` | Ratings, prices, scores |
-| **Boolean** | `True`, `False` | `Value::Bool` | Flags, status indicators |
-| **Null** | `None` | `Value::Null` | Missing/empty values |
-| **Array** | `["ai", "science"]` | `Value::Array` | Tags, categories, lists |
-| **Nested Object** | `{"key": "value"}` | `Value::Object` | Structured data |
+| Type | Python Example | Notes |
+|------|----------------|-------|
+| **String** | `"Alice"` | Text data, IDs, categories |
+| **Integer** | `42`, `2024` | Counts, years, IDs |
+| **Float** | `4.5`, `29.99` | Ratings, prices, scores |
+| **Boolean** | `True`, `False` | Flags, status indicators |
+| **Null** | `None` | Missing/empty values |
+| **Array** | `["ai", "science"]` | Tags, categories, lists |
+| **Nested Object** | `{"key": "value"}` | Structured data |
+
+Integers and floats compare by magnitude across every operator, so a stored integer `10` matches `{"eq": 10.0}` and `{"gte": 10.0}` alike. Booleans and strings do not cross into numbers.
 
 <br/>
 
 ### Filter Operators Reference
 
-These operators can be used in metadata filters:
+A filter is a dict of field names. A field maps either to a plain value, which means equality, or to a dict of operators, all of which must hold.
 
 | Operator | Usage | Example | Description |
 |----------|-------|---------|-------------|
-| **Direct equality** | `{"field": value}` | `{"author": "Alice"}` | Exact equality for any type |
+| **Direct equality** | `{"field": value}` | `{"author": "Alice"}` | Equality for strings, numbers, booleans, null and arrays |
+| `eq` | `{"eq": value}` | `{"source": {"eq": {"kind": "web"}}}` | Equality, including for nested objects |
+| `ne` | `{"ne": value}` | `{"author": {"ne": "Alice"}}` | Not equal |
 | `gt` | `{"gt": value}` | `{"rating": {"gt": 4.0}}` | Greater than (numeric) |
 | `gte` | `{"gte": value}` | `{"year": {"gte": 2024}}` | Greater than or equal (numeric) |
 | `lt` | `{"lt": value}` | `{"price": {"lt": 30}}` | Less than (numeric) |
@@ -34,53 +38,116 @@ These operators can be used in metadata filters:
 | `endswith` | `{"endswith": value}` | `{"file": {"endswith": ".pdf"}}` | String ends with substring |
 | `in` | `{"in": [values]}` | `{"lang": {"in": ["en", "es"]}}` | Value is in the provided array |
 
+Three behaviours are worth knowing.
+
+**A record that lacks the field never matches, whatever the operator.** That includes `ne`. `{"status": {"ne": "archived"}}` does not match a record with no `status` at all, so a filter for "status is not archived" excludes records that never had a status.
+
+**A dict value is always read as operators.** Direct equality against a nested object has no plain form, because the two would be indistinguishable, so write it as `{"source": {"eq": {"kind": "web"}}}`. Writing `{"source": {"kind": "web"}}` raises `ValueError: Unknown filter operation: kind`.
+
+**An unrecognised operator raises `ValueError` before the search runs**, rather than quietly matching nothing.
+
+**Filtering happens after the graph search.** The index finds the `top_k` nearest vectors first and then discards the ones the filter rejects, so a selective filter can return fewer than `top_k` results, or none. Raise `top_k` when you filter.
+
 <br/>
 
 ### Practical Filter Examples
 
-Below are common real-world examples of how to apply metadata filters using ZeusDB's metadata filtering:
+The examples below all run against this index:
 
-**Example 1 - Find high-quality recent documents**
 ```python
-filter = {
-    "published": True,
-    "rating": {"gte": 4.0},
-    "year": {"gte": 2024}
-}
+from zeusdb import VectorDatabase
 
-results = index.search(vector=query_embedding, filter=filter, top_k=5)
+vdb = VectorDatabase()
+index = vdb.create("hnsw", dim=4, space="l2")
+index.add([
+    {"id": "doc_1", "values": [0.1, 0.1, 0.1, 0.1], "metadata": {
+        "author": "Alice", "rating": 4.5, "year": 2024, "price": 29.99,
+        "published": True, "tags": ["ai", "science"], "title": "The Guide",
+        "filename": "report.pdf", "lang": "en"}},
+    {"id": "doc_2", "values": [0.2, 0.2, 0.2, 0.2], "metadata": {
+        "author": "Bob", "rating": 3.0, "year": 2023, "price": 45.00,
+        "published": False, "tags": ["cooking"], "title": "A Book",
+        "filename": "notes.txt", "lang": "es"}},
+    {"id": "doc_3", "values": [0.3, 0.3, 0.3, 0.3], "metadata": {
+        "author": "Charlie", "rating": 5.0, "year": 2026, "price": 25.00,
+        "published": True, "tags": ["ai"], "title": "Theory",
+        "filename": "paper.pdf", "lang": "fr"}},
+])
+query_embedding = [0.1, 0.1, 0.1, 0.1]
+
+def matched(filter, top_k=10):
+    return [hit["id"] for hit in index.search(vector=query_embedding, filter=filter, top_k=top_k)]
+```
+
+**Example 1 - Filtering happens after the search, so raise `top_k`**
+
+```python
+# doc_3 is the furthest of the three from the query, so a top_k of 1 finds
+# nothing once the filter is applied
+print(matched({"author": "Charlie"}, top_k=1))
+print(matched({"author": "Charlie"}, top_k=10))
+```
+
+*Output*
+```text
+[]
+['doc_3']
 ```
 
 <br />
 
-**Example 2 - Find documents by specific authors**
+**Example 2 - Find high-quality recent documents**
 ```python
-filter = {"author": {"in": ["Alice", "Bob", "Charlie"]}}
-results = index.search(vector=query_embedding, filter=filter, top_k=5)
+print(matched({"published": True, "rating": {"gte": 4.0}, "year": {"gte": 2024}}))
+# ['doc_1', 'doc_3']
 ```
 
 <br />
 
-**Example 3 - Find AI-related content**
+**Example 3 - Find documents by specific authors**
 ```python
-filter = {"tags": {"contains": "ai"}}
-results = index.search(vector=query_embedding, filter=filter, top_k=5)
+print(matched({"author": {"in": ["Alice", "Bob"]}}))
+# ['doc_1', 'doc_2']
 ```
 
 <br />
 
-**Example 4 - Find documents in price range**
+**Example 4 - Find AI-related content**
 ```python
-filter = {"price": {"gte": 20.0, "lte": 40.0}}
-results = index.search(vector=query_embedding, filter=filter, top_k=5)
+print(matched({"tags": {"contains": "ai"}}))
+# ['doc_1', 'doc_3']
 ```
 
 <br />
 
-**Example 5 - Find documents with specific file types**
+**Example 5 - Find documents in price range**
 ```python
-filter = {"filename": {"endswith": ".pdf"}}
-results = index.search(vector=query_embedding, filter=filter, top_k=5)
+print(matched({"price": {"gte": 20.0, "lte": 40.0}}))
+# ['doc_1', 'doc_3']
+```
+
+<br />
+
+**Example 6 - Find documents with specific file types**
+```python
+print(matched({"filename": {"endswith": ".pdf"}}))
+# ['doc_1', 'doc_3']
+```
+
+<br />
+
+**Example 7 - Exclude an author**
+```python
+print(matched({"author": {"ne": "Alice"}}))
+# ['doc_2', 'doc_3']
+```
+
+<br />
+
+**Example 8 - Match a whole array**
+```python
+print(matched({"tags": ["ai"]}))
+# ['doc_3']
 ```
 
 

--- a/docs/source/vector_database/persistence.md
+++ b/docs/source/vector_database/persistence.md
@@ -4,12 +4,13 @@ ZeusDB Vector Database provides production-ready persistence capabilities that a
 
 The persistence system supports:
 
-✅ **Complete state preservation** – vectors, metadata, HNSW graph structure, and quantization models  
+✅ **Complete state preservation** – vectors, per-record metadata, index level metadata, ID mappings, HNSW graph structure, and quantization models  
 ✅ **Hybrid storage format** – efficient binary encoding for vectors with human-readable JSON for metadata  
-✅ **Quantization support** – seamlessly handles both raw and quantized storage modes  
-✅ **Training state recovery** – preserves PQ training progress and model parameters  
-✅ **Cross-platform compatibility** – indexes saved on one system can be loaded on another  
+✅ **Quantization support** – seamlessly handles both raw and quantized storage modes, including the trained codebook and rerank calibration  
+✅ **Training state recovery** – an index saved mid-collection resumes collecting toward its training threshold  
+✅ **Format versioning** – a directory this build cannot interpret is refused rather than misread  
 
+**`save()` and `load()` print progress to stdout.** Every step writes a line. This is not configurable, so redirect stdout if it is a problem in your application.
 
 ## Saving an Index - .save()
 
@@ -40,32 +41,37 @@ None
 **Example 1 - How to save an Index**
 
 ```python
-# Import the vector database module
-from zeusdb_vector_database import VectorDatabase
+from zeusdb import VectorDatabase
 import numpy as np
+import os
 
 # Create and populate an index
 vdb = VectorDatabase()
-index = vdb.create("hnsw", dim=1536, space="cosine")
+index = vdb.create("hnsw", dim=1536, space="cosine", expected_size=1000)
 
-# Add some vectors
-vectors = np.random.random((1000, 1536)).astype(np.float32)
-data = {
-    'vectors': vectors.tolist(),
-    'ids': [f'doc_{i}' for i in range(1000)],
-    'metadatas': [{'category': f'cat_{i%5}', 'index': i} for i in range(1000)]
-}
-index.add(data)
+rng = np.random.default_rng(1)
+vectors = rng.random((1000, 1536), dtype=np.float32)
+index.add({
+    "ids": [f"doc_{i}" for i in range(1000)],
+    "embeddings": vectors,
+    "metadatas": [{"category": f"cat_{i % 5}", "index": i} for i in range(1000)],
+})
 
 # Save the complete index to disk
 index.save("my_index.zdb")
+print("saved:", sorted(os.listdir("my_index.zdb")))
+```
+
+*Output, with the progress lines omitted*
+```text
+saved: ['config.json', 'hnsw_index.hnsw.data', 'hnsw_index.hnsw.graph', 'manifest.json', 'mappings.bin', 'metadata.json', 'vectors.bin']
 ```
 
 <br />
 
 ## Loading an Index - .load()
 
-Use the .load() method to restore a previously saved index.
+Use the `.load()` method to restore a previously saved index.
 
 **VectorDatabase.<span style="color: #663399;">load</span>**(<br/>
 &emsp;&emsp;**path: str**<br/>
@@ -88,83 +94,96 @@ HNSWIndex
 ```
 
 
-## Examples
-
 **Example 2 - How to load an Index**
 
 ```python
 # Load the index from disk
-vdb = VectorDatabase()
 loaded_index = vdb.load("my_index.zdb")
 
-# Verify the index loaded correctly
-print(f"Loaded index with {loaded_index.get_vector_count()} vectors")
-print(f"Index configuration: {loaded_index.info()}")
+print("vectors:", loaded_index.get_vector_count())
+print(loaded_index.info())
 
-# Test search on loaded index
-query_vector = np.random.random(1536).tolist()
-results = loaded_index.search(query_vector, top_k=3)
-print(f"Search returned {len(results)} results")
-print(results)
+results = loaded_index.search(vectors[0].tolist(), top_k=3)
+print("top hit:", results[0]["id"])
 ```
+
+*Output, with the progress lines omitted*
+```text
+vectors: 1000
+HNSWIndex(dim=1536, space=cosine, m=16, ef_construction=200, expected_size=1000, vectors=1000, quantization=none)
+top hit: doc_0
+```
+
+**Loading reads the saved graph back rather than rebuilding it**, so a reloaded index returns the same result pages as the index that was saved, with the same IDs and the same scores. Load time is proportional to the size of the directory rather than to the cost of building the index: 50,000 records at 1,536 dimensions load in about a second against a build of over two minutes.
+
+The graph is rebuilt by re-inserting every record only when the saved graph cannot be used, which covers a directory whose graph files were lost or damaged and one written by a release too old for this build to interpret. An index saved by an earlier release therefore still loads, with no user action required. Set `ZEUSDB_LOAD_REBUILD_GRAPH=1` to ask for that rebuild on a directory whose graph is perfectly readable, which is how an index built by an earlier release picks up graph improvements made since.
 
 <br />
 
 ### 🗜️ Persistence with Product Quantization
 
-Persistence seamlessly handles quantized indexes, preserving both the compression model and training state:
+Persistence seamlessly handles quantized indexes. A quantized index comes back quantized, with its codebook, training state and rerank calibration intact:
 
 ```python
-# Create index with quantization
+from zeusdb import VectorDatabase
+import numpy as np
+import os
+
 quantization_config = {
     'type': 'pq',
     'subvectors': 8,
     'bits': 8,
     'training_size': 1000,
-    'storage_mode': 'quantized_only'
+    'storage_mode': 'quantized_with_raw'
 }
 
 vdb = VectorDatabase()
-index = vdb.create("hnsw", dim=1536, quantization_config=quantization_config)
+index = vdb.create("hnsw", dim=1536, expected_size=2000,
+                   quantization_config=quantization_config)
 
-# Add enough vectors to trigger PQ training
-vectors = np.random.random((2000, 1536)).astype(np.float32)
-data = {
-    'vectors': vectors.tolist(),
-    'ids': [f'vec_{i}' for i in range(2000)]
-}
+rng = np.random.default_rng(2)
+index.add({
+    "ids": [f"vec_{i}" for i in range(2000)],
+    "embeddings": rng.random((2000, 1536), dtype=np.float32),
+})
 
-add_result = index.add(data)
-print(f"Added {add_result.total_inserted} vectors")
-print(f"Training progress: {index.get_training_progress():.1f}%")
-print(f"Quantization active: {index.is_quantized()}")
-
-# Save quantized index
+print("quantization active:", index.is_quantized())
 index.save("quantized_index.zdb")
 
-# Load and verify quantization state is preserved
 loaded_index = vdb.load("quantized_index.zdb")
-print(f"Loaded quantization state: {loaded_index.is_quantized()}")
-print(f"Compression info: {loaded_index.get_quantization_info()}")
+print("quantization active after load:", loaded_index.is_quantized())
+print("storage mode after load:", loaded_index.get_storage_mode())
+print("saved:", sorted(os.listdir("quantized_index.zdb")))
+```
+
+*Output, with the progress lines omitted*
+```text
+quantization active: True
+quantization active after load: True
+storage mode after load: quantized_active
+saved: ['config.json', 'hnsw_index.hnsw.data', 'hnsw_index.hnsw.graph', 'manifest.json', 'mappings.bin', 'metadata.json', 'pq_centroids.bin', 'pq_codes.bin', 'quantization.json', 'vectors.bin']
 ```
 
 <br/>
 
 ### Index Directory Structure
-The .save() method creates a structured directory containing all index components:
+The `.save()` method creates a structured directory containing all index components:
 
-```
+```text
 my_index.zdb/
 ├── manifest.json           # Index metadata and file inventory
-├── config.json             # HNSW configuration parameters
+├── config.json             # HNSW configuration and index level metadata
 ├── mappings.bin            # ID mappings (binary format)
-├── metadata.json           # Vector metadata (JSON format)
-├── vectors.bin             # Raw vectors (if applicable)
+├── metadata.json           # Per-record metadata (JSON format)
+├── vectors.bin             # Raw vectors (whenever the index holds any)
 ├── quantization.json       # PQ configuration (if enabled)
 ├── pq_centroids.bin        # Trained centroids (if PQ trained)
 ├── pq_codes.bin            # Quantized codes (if PQ active)
-└── hnsw_index.hnsw.graph   # HNSW graph structure
+├── hnsw_index.hnsw.graph   # HNSW graph structure
+└── hnsw_index.hnsw.data    # HNSW graph payload
 ```
+
+`manifest.json` lists both graph files under `files_included`. The load path restores the saved graph rather than rebuilding it, so both are required to reopen a directory holding records.
 
 <br/>
 
@@ -177,94 +196,79 @@ import numpy as np
 
 # === PHASE 1: CREATE AND POPULATE INDEX ===
 vdb = VectorDatabase()
-original_index = vdb.create("hnsw", dim=1536, space="cosine", m=16)
+original_index = vdb.create("hnsw", dim=1536, space="cosine", expected_size=500)
 
-# Add vectors with rich metadata
-np.random.seed(42)  # For reproducible results
-vectors = np.random.random((500, 1536)).astype(np.float32)
+rng = np.random.default_rng(42)
+vectors = rng.random((500, 1536), dtype=np.float32)
 
-data = {
-    'vectors': vectors.tolist(),
-    'ids': [f'doc_{i:03d}' for i in range(500)],
-    'metadatas': [
+original_index.add({
+    "ids": [f"doc_{i:03d}" for i in range(500)],
+    "embeddings": vectors,
+    "metadatas": [
         {
-            'category': ['science', 'tech', 'health', 'finance'][i % 4],
-            'priority': i % 10,
-            'published': i % 2 == 0,
-            'tags': ['important', 'featured'] if i % 5 == 0 else ['standard']
+            "category": ["science", "tech", "health", "finance"][i % 4],
+            "priority": i % 10,
+            "published": i % 2 == 0,
+            "tags": ["important", "featured"] if i % 5 == 0 else ["standard"],
         }
         for i in range(500)
-    ]
-}
-
-# Populate the index
-add_result = original_index.add(data)
-print(f"✅ Added {add_result.total_inserted} vectors")
+    ],
+})
 
 # Add some index-level metadata
 original_index.add_metadata({
     "dataset": "demo_collection",
     "created_by": "data_team",
-    "version": "1.0"
+    "version": "1.0",
 })
 
-# Test search before saving
-query_vector = vectors[0].tolist()  # Use first vector as query
+query_vector = vectors[0].tolist()
 original_results = original_index.search(query_vector, top_k=3)
-print(f"🔍 Original search found {len(original_results)} results")
 
-# === PHASE 2: SAVE INDEX ===
-save_path = "demo_index.zdb"
-original_index.save(save_path)
-print(f"💾 Index saved to {save_path}")
+# === PHASE 2: SAVE, THEN LOAD ===
+original_index.save("demo_index.zdb")
+loaded_index = vdb.load("demo_index.zdb")
 
-# === PHASE 3: LOAD INDEX ===
-loaded_index = vdb.load(save_path)
-print(f"📂 Index loaded from {save_path}")
-
-# === PHASE 4: VERIFY INTEGRITY ===
-# Check vector count
+# === PHASE 3: VERIFY INTEGRITY ===
 assert loaded_index.get_vector_count() == original_index.get_vector_count()
-print(f"✅ Vector count verified: {loaded_index.get_vector_count()}")
-
-# Check configuration
 assert loaded_index.info() == original_index.info()
-print(f"✅ Configuration verified: {loaded_index.info()}")
+assert loaded_index.get_all_metadata() == original_index.get_all_metadata()
 
-# Check metadata preservation
-original_meta = original_index.get_all_metadata()
-loaded_meta = loaded_index.get_all_metadata()
-#assert original_meta == loaded_meta
-print(f"Original meta fields: {len(original_meta)}, Loaded meta fields: {len(loaded_meta)}")
-print(f"✅ Index metadata verified: {len(loaded_meta)} fields")
-
-# Test search consistency
 loaded_results = loaded_index.search(query_vector, top_k=3)
-assert len(loaded_results) == len(original_results)
-assert loaded_results[0]['id'] == original_results[0]['id']
-print("✅ Search consistency verified")
+assert [r["id"] for r in loaded_results] == [r["id"] for r in original_results]
 
-# Test filtering on loaded index
-filtered_results = loaded_index.search(
-    query_vector, 
-    filter={'category': 'science', 'published': True}, 
-    top_k=5
+filtered = loaded_index.search(
+    query_vector,
+    filter={"category": "science", "published": True},
+    top_k=20,
 )
-print(f"🔍 Filtered search found {len(filtered_results)} results")
 
-print("\n🎉 Complete persistence workflow successful!")
+print("records:", loaded_index.get_vector_count())
+print("index metadata fields:", len(loaded_index.get_all_metadata()))
+print("filtered hits:", len(filtered))
+print("all checks passed")
+```
+
+*Output, with the progress lines omitted*
+```text
+records: 500
+index metadata fields: 3
+filtered hits: 5
+all checks passed
 ```
 
 ### ⚠️ Important Notes on Persistence
-- Directory Structure: The .save() method creates a directory, not a single file. Ensure you have write permissions for the target location.
+- **Directory, not a file**: The `.save()` method creates a directory. Ensure you have write permissions for the target location.
 
-- Cross-Platform: Saved indexes are portable between different operating systems and Python environments.
+- **Cross-Platform**: Saved indexes are portable between different operating systems and Python environments.
 
-- Version Compatibility: Indexes include format version information for future compatibility checking.
+- **Version Compatibility**: The manifest records a format version. This build writes 1.1.0 and reads any 1.x. A different major version is refused.
 
-- Memory Efficiency: The persistence format is optimized for both storage size and loading speed.
+- **Not atomic**: Files are written one at a time into the target directory. An interrupted save leaves a partial directory behind, and a later `load()` of it fails rather than returning a truncated index. Save to a new path and move it into place if you need an atomic swap.
 
-- Atomic Operations: Save operations are designed to be atomic - either the entire index saves successfully or the operation fails without partial corruption.
+- **Overwriting is not clean either**: Saving over an existing directory replaces files individually and does not remove ones that no longer apply. Save to a fresh directory.
+
+- **Integrity check on load**: The restored record count is checked against the count in `config.json`. A missing or truncated data file fails the load with a message naming what disagreed.
 
 
 <br />

--- a/docs/source/vector_database/product_quantization.md
+++ b/docs/source/vector_database/product_quantization.md
@@ -1,16 +1,18 @@
 # Product Quantization
 
-Product Quantization (PQ) is a vector compression technique that significantly reduces memory usage while preserving high search accuracy. Commonly used in HNSW-based vector databases, PQ works by dividing each vector into subvectors and quantizing them independently. This enables compression ratios of 4× to 256×, making it ideal for large-scale, high-dimensional datasets.
+Product Quantization (PQ) is a vector compression technique that reduces memory usage by dividing each vector into subvectors and quantizing them independently. A record's compressed form is one byte per subvector, whatever the dimension, so an index over 1536-dimensional vectors with 8 subvectors stores 8 bytes per code in place of 6144 bytes of float32.
 
-ZeusDB Vector Database’s PQ implementation features:
+ZeusDB Vector Database's PQ implementation features:
 
-✅ Intelligent Training – PQ model trains automatically at defined thresholds
+✅ Automatic training, triggered on the `add()` call that reaches the configured threshold
 
-✅ Efficient Memory Use – Store 4× to 256× more vectors in the same RAM footprint
+✅ Compact codes, one byte per subvector per record
 
-✅ Fast Approximate Search – Uses Asymmetric Distance Computation (ADC) for high-speed search computation
+✅ Asymmetric Distance Computation (ADC) for fast search against the codes
 
-✅ Seamless Operation – Index automatically switches from raw to quantized storage modes
+✅ Automatic switch from raw to quantized storage once training completes
+
+Compression is not free, and the accuracy cost is much larger than the memory saving suggests. Read [Quantized search accuracy](#quantized-search-accuracy) before choosing a storage mode.
 
 <br />
 
@@ -21,23 +23,93 @@ ZeusDB Vector Database’s PQ implementation features:
 type : *str, required*
 :   Quantization algorithm type. Currently only supports `"pq"` for Product Quantization.
 
-subvectors : *int, default 8*
-:   Number of vector subspaces (must divide dimension evenly). The vector is split into this many subvectors for independent quantization. Valid range: 1 to dimension.
+subvectors : *int, default derived from the dimension*
+:   Number of vector subspaces (must divide dimension evenly). The vector is split into this many subvectors for independent quantization. Valid range: 1 to dimension. The default is `dim / 32`, clamped to between 8 and 192 and snapped to a divisor of `dim`, which holds the compression ratio at 128x from `dim=256` upward.
 
 bits : *int, default 8*
-:   Bits per quantized code (controls centroids per subvector). Determines the number of centroids as 2^bits. Higher values provide better accuracy but use more memory. Valid range: 1-8.
+:   Bits per quantized code, which sets the centroids per subvector to 2^bits. Valid range: 1-8. Lowering it shrinks the fixed codebook and centroid distance table but not the per-record code, which is one byte per subvector at every value, and it costs recall.
 
-training_size : *int, default 1000*
-:   Minimum vectors needed for stable k-means clustering during quantization training. Must be ≥ 1000 for reliable centroid estimation.
+training_size : *int, default derived, 10,000 at the default bits*
+:   Records collected before training is triggered. When passed explicitly it must be at least 1000, the minimum for stable k-means clustering.
 
 max_training_vectors : *int, default None*
-:   Maximum vectors used during training (optional limit). When specified, limits the number of vectors used for training even if more are available. Must be ≥ training_size.
+:   Maximum vectors used during training (optional limit). When specified, must be ≥ training_size.
 
 storage_mode : *str, default "quantized_only"*
 :   Storage strategy for vectors. Options:
-    * `"quantized_only"` - Memory optimized, stores only quantized vectors
-    * `"quantized_with_raw"` - Keep both quantized and raw vectors for exact reconstruction
+    * `"quantized_only"` - Stores only quantized codes once trained. Lowest memory, and results cannot be reranked, so recall is far below an unquantized index.
+    * `"quantized_with_raw"` - Keeps raw vectors alongside the codes. Search reranks against them by default and matches unquantized recall.
 ```
+
+**The compression ratio is `dim × 4 / subvectors`.** More subvectors means a longer code, so it lowers the compression ratio and raises accuracy. Fewer subvectors means the opposite. At `dim=1536`, 8 subvectors gives 768x and 48 subvectors gives 128x. Do not quote a ratio without the dimension, since the default `subvectors` scales with it:
+
+| `dim` | default `subvectors` | compression |
+|-------|----------------------|-------------|
+| 64 | 8 | 32x |
+| 128 | 8 | 64x |
+| 256 | 8 | 128x |
+| 768 | 24 | 128x |
+| 1536 | 48 | 128x |
+| 3072 | 96 | 128x |
+
+<br/>
+
+## 📦 Storage modes
+
+| Mode | What it stores | Rerank available | Memory |
+|------|----------------|------------------|--------|
+| `quantized_only` | Codes for every record; the raw vectors collected for training are released when training completes | No | Lowest of the three |
+| `quantized_with_raw` | Codes and raw vectors for every record | Yes | Between `quantized_only` and no quantization |
+
+Measured resident memory, 50,000 records of real 1536-dimensional OpenAI embeddings, one process each:
+
+| Configuration | Resident | Against unquantized |
+| --- | --- | --- |
+| No quantization | 806 MiB | 1.00x |
+| `quantized_with_raw` | 475 MiB | 0.59x |
+| `quantized_only` | 181 MiB | 0.22x |
+
+Two consequences of `quantized_only` are worth knowing before you pick it.
+
+**Once training completes every record exists only as a code, so the vector you read back is an approximation.** `get_records(..., return_vector=True)` and `search(..., return_vector=True)` reconstruct the vector from its code, so what they hand back is close to the value supplied rather than equal to it. Only `quantized_with_raw` reads back exactly. `get_stats()["raw_vectors_stored"]` reports zero once a `quantized_only` index has trained.
+
+**Recall cannot be recovered.** Without raw vectors there is nothing to rerank against, so no tuning restores the accuracy the codes discard. See the next section.
+
+Quantization saves little at low dimension, because the vectors are a small share of what an HNSW index holds there. Below roughly `dim=256` the saving falls under a fifth of what an unquantized index holds, and `create()` warns when a configuration cannot repay its fixed cost at the declared `expected_size`.
+
+<br/>
+
+(quantized-search-accuracy)=
+## 🎯 Quantized search accuracy
+
+**Quantized search without reranking is far less accurate than raw search, and `quantized_only` cannot be repaired by tuning.** ADC scores candidates against the codes, and a code discards most of the information in a vector. Reranking fixes this by over-fetching candidates and rescoring them against raw vectors, which is only possible under `quantized_with_raw`.
+
+Measured on 50,000 real OpenAI embeddings at `dim=1536`, recall at 10 was roughly 0.49 for `quantized_only` against 0.99 unquantized, and no setting recovers it. On 6,000 clustered 128-dimensional vectors with 8 subvectors, recall at 10 against exact search:
+
+| Configuration | Recall@10 |
+|---------------|-----------|
+| No quantization | 1.00 |
+| `quantized_only` | 0.16 |
+| `quantized_with_raw`, `rerank=0` | 0.15 |
+| `quantized_with_raw`, default rerank | 1.00 |
+
+The exact figures depend on your data, but the shape does not. If you need quantization and you need accuracy, use `quantized_with_raw` and leave rerank on.
+
+### The `rerank` argument
+
+`search()` takes a `rerank` argument on a quantized index:
+
+- `rerank` omitted uses a fetch calibrated on your own data. When a `quantized_with_raw` index finishes training it measures how deep a search has to fetch into the code ordering to reach recall at 10 of 0.99 on the training records, how that depth grows with the record count, and how it grows with `top_k`. `get_stats()` reports the calibration under the `rerank_` keys, and `rerank_default_fetch` is the number of candidates a search at `top_k=10` fetches and rescores at the current record count.
+- `rerank=N` for N of 1 or more fetches `top_k × N` candidates, a fixed multiple that does not move with the corpus. Use it to override the default deliberately, for example to trade recall for query time.
+- `rerank=0` turns reranking off and returns the ADC scores and ordering.
+- `rerank` has no effect on an unquantized index or on a `quantized_only` one. Both ignore it.
+- With rerank on, the scores you get back are raw-vector distances. With it off, they are ADC estimates. The two are not comparable, so a threshold tuned against one does not carry to the other.
+
+An index trained before the calibration existed, including any index loaded from a directory saved by an earlier release, carries no calibration and falls back to a fixed fetch of 2% of the record count, floored at 250 candidates and at `5 × top_k`. `get_stats()` reports `rerank_calibrated: false` for it. Rebuild the index to calibrate it.
+
+### `ef_search` does nothing on a reranked quantized search
+
+The graph traversal is widened to the rerank fetch, and the fetch already exceeds any `ef_search` a caller is likely to set, so a smaller value is discarded. Raising it above the fetch buys no recall either, because the candidates are limited by the code ordering rather than by the traversal, and it costs query time. Change `rerank` instead. On an unquantized search, and on a quantized search with `rerank=0`, `ef_search` applies normally.
 
 <br/>
 
@@ -45,155 +117,139 @@ storage_mode : *str, default "quantized_only"*
 **🗜️ Usage Example 1**
 
 ```python
-from zeusdb_vector_database import VectorDatabase
+from zeusdb import VectorDatabase
 import numpy as np
 
-# Create index with product quantization
 vdb = VectorDatabase()
 
-# Configure quantization for memory efficiency
 quantization_config = {
-    'type': 'pq',                  # `pq` for Product Quantization
-    'subvectors': 8,               # Divide 1536-dim vectors into 8 subvectors of 192 dims each
-    'bits': 8,                     # 256 centroids per subvector (2^8)
-    'training_size': 10000,        # Train when 10k vectors are collected
-    'max_training_vectors': 50000  # Use max 50k vectors for training
+    'type': 'pq',                        # `pq` for Product Quantization
+    'subvectors': 8,                     # 8 subvectors of 192 dims each
+    'bits': 8,                           # 256 centroids per subvector (2^8)
+    'training_size': 1000,               # Train once 1,000 records are collected
+    'storage_mode': 'quantized_with_raw' # Keep raw vectors so results can be reranked
 }
 
-# Create index with quantization
-# This will automatically handle training when enough vectors are added
 index = vdb.create(
     index_type="hnsw",
-    dim=1536,                                  # OpenAI `text-embedding-3-small` dimension
-    quantization_config=quantization_config    # Add the compression configuration
+    dim=1536,                                # OpenAI `text-embedding-3-small` dimension
+    expected_size=2500,
+    quantization_config=quantization_config
 )
 
-# Add vectors - training triggers automatically at threshold
-documents = [
-    {
-        "id": f"doc_{i}", 
-        "values": np.random.rand(1536).astype(float).tolist(),
-        "metadata": {"category": "tech", "year": 2026}
-    }
-    for i in range(15000) 
-]
+# Add vectors. Training triggers automatically at the threshold.
+rng = np.random.default_rng(0)
+documents = {
+    "ids": [f"doc_{i}" for i in range(2500)],
+    "embeddings": rng.random((2500, 1536), dtype=np.float32),
+    "metadatas": [{"category": "tech", "year": 2026} for _ in range(2500)],
+}
 
-# Training will trigger automatically when 10k vectors are added
 result = index.add(documents)
-print(f"Added {result.total_inserted} vectors")
+print("inserted:", result.total_inserted)
 
 # Check quantization status
-print(f"Training progress: {index.get_training_progress():.1f}%")
-print(f"Storage mode: {index.get_storage_mode()}")
-print(f"Is quantized: {index.is_quantized()}")
+print("training progress:", f"{index.get_training_progress():.1f}%")
+print("storage mode:", index.get_storage_mode())
+print("is quantized:", index.is_quantized())
 
 # Get compression statistics
 quant_info = index.get_quantization_info()
-if quant_info:
-    print(f"Compression ratio: {quant_info['compression_ratio']:.1f}x")
-    print(f"Memory usage: {quant_info['memory_mb']:.1f} MB")
+print("compression ratio:", f"{quant_info['compression_ratio']:.1f}x")
+print("codebook memory:", f"{quant_info['memory_mb']:.1f} MB")
 
-# Search works seamlessly with quantized storage
-query_vector = np.random.rand(1536).astype(float).tolist()
+# Search works the same way on a quantized index
+query_vector = rng.random(1536, dtype=np.float32)
 results = index.search(vector=query_vector, top_k=3)
-
-# Simply print raw results
-print(results)
+print("results:", len(results), "| keys:", sorted(results[0].keys()))
 ```
 
-Results
+*Output*
+```text
+inserted: 2500
+training progress: 100.0%
+storage mode: quantized_active
+is quantized: True
+compression ratio: 768.0x
+codebook memory: 1.5 MB
+results: 3 | keys: ['id', 'metadata', 'score']
+```
+
+The result IDs and scores depend on the data, so they are not shown. Production indexes use a much larger `training_size`; 1,000 is the minimum the validator accepts and keeps this example quick. `create()` emits a `UserWarning` for `quantized_with_raw` describing the memory trade, and another when a `subvectors` value you passed implies a ratio above 50x, as the explicit 8 here does at `dim=1536`.
+
+`index.info()` reports the quantization state as well:
+
 ```python
-[
-{'id': 'doc_9719', 'score': 0.5133496522903442, 'metadata': {'category': 'tech', 'year': 2026}},
-{'id': 'doc_8148', 'score': 0.5139288306236267, 'metadata': {'category': 'tech', 'year': 2026}}, 
-{'id': 'doc_7822', 'score': 0.5151920914649963, 'metadata': {'category': 'tech', 'year': 2026}}, 
-]
+print(index.info())
+```
+
+*Output*
+```text
+HNSWIndex(dim=1536, space=cosine, m=16, ef_construction=200, expected_size=2500, vectors=2500, quantization=pq(subvectors=8, bits=8, trained, active, compression=768.0x))
 ```
 
 <br />
 
-**🗜️Usage Example 2 - with explicit storage mode**
+**🗜️ Usage Example 2 - with explicit storage mode**
 
 ```python
-from zeusdb_vector_database import VectorDatabase
-import numpy as np
+from zeusdb import VectorDatabase
 
-# Create index with product quantization
 vdb = VectorDatabase()
 
-# Configure quantization for memory efficiency
 quantization_config = {
-    'type': 'pq',                  # `pq` for Product Quantization
-    'subvectors': 8,               # Divide 1536-dim vectors into 8 subvectors of 192 dims each
-    'bits': 8,                     # 256 centroids per subvector (2^8)
-    'training_size': 10000,        # Train when 10k vectors are collected
-    'max_training_vectors': 50000,  # Use max 50k vectors for training
-    'storage_mode': 'quantized_only'  # Explicitly set storage mode to only keep quantized values
+    'type': 'pq',
+    'subvectors': 8,
+    'bits': 8,
+    'training_size': 10000,
+    'max_training_vectors': 50000,
+    'storage_mode': 'quantized_only'    # Drop raw vectors once training completes
 }
 
-# Create index with quantization
-# This will automatically handle training when enough vectors are added
 index = vdb.create(
     index_type="hnsw",
-    dim=3072,                                  # OpenAI `text-embedding-3-large` dimension
-    quantization_config=quantization_config    # Add the compression configuration
+    dim=3072,                           # OpenAI `text-embedding-3-large` dimension
+    expected_size=100000,
+    quantization_config=quantization_config
 )
-
 ```
 
 <br />
 
 ## ⚙️ Configuration Guidelines
 
-For Balanced Memory & Accuracy (Recommended to start with)
+For accuracy with a memory saving (recommended):
+```python
+quantization_config = {
+    'type': 'pq',                         # subvectors and training_size derived
+    'storage_mode': 'quantized_with_raw'  # Keep raw vectors so search can rerank
+}
+# Matches unquantized recall through reranking.
+# Measured 0.59x the resident memory of an unquantized index at 50,000
+# records of dim=1536.
+```
+
+For maximum memory saving, where recall does not matter:
 ```python
 quantization_config = {
     'type': 'pq',
-    'subvectors': 8,      # Balanced: moderate compression, good accuracy
-    'bits': 8,            # 256 centroids per subvector (high precision)
-    'training_size': 10000,  # Or higher for large datasets
-    'storage_mode': 'quantized_only'  # Default, memory efficient
+    'storage_mode': 'quantized_only'  # Default. No raw vectors, no reranking
 }
-# Achieves ~16x–32x compression with strong recall for most applications
+# Measured 0.22x the resident memory of an unquantized index at 50,000
+# records of dim=1536, returning roughly half the correct results.
 ```
 
-
-For Memory Optimization:
-```python
-quantization_config = {
-    'type': 'pq',
-    'subvectors': 16,      # More subvectors = better compression
-    'bits': 6,             # Fewer bits = less memory per centroid
-    'training_size': 20000,
-    'storage_mode': 'quantized_only'
-}
-# Achieves ~32x compression ratio
-```
-
-For Accuracy Optimization:
-```python
-quantization_config = {
-    'type': 'pq',
-    'subvectors': 4,       # Fewer subvectors = better accuracy
-    'bits': 8,             # More bits = more precise quantization
-    'training_size': 50000 # More training data = better centroids
-    'storage_mode': 'quantized_with_raw'  # Keep raw vectors for exact recall
-}
-# Achieves ~4x compression ratio with minimal accuracy loss
-```
+Leave `subvectors` and `bits` at their defaults unless you have measured a reason to move them. Raising `subvectors` lowers the compression ratio, costs memory and build time, and returns almost nothing on recall at the default rerank. Lowering `bits` shrinks only the fixed tables and costs recall.
 
 ### 📊 Performance Characteristics
 
-- Training: Occurs once when threshold is reached (typically 1-5 minutes for 50k vectors)
-- Memory Reduction: 4x-256x depending on configuration
-- Search Speed: Comparable or faster than raw vectors due to ADC optimization
-- Accuracy Impact: Typically 1-5% recall reduction with proper tuning
+- **Training**: happens once, on the `add()` call that reaches `training_size`. That call takes noticeably longer than the others. Training alone is roughly linear in the training set, measured at 3.1 s for 1,000 vectors and 40.6 s for 10,000 at `dim=768`. On `quantized_with_raw` it also calibrates the rerank fetch.
+- **Memory**: a record's code is `subvectors` bytes against `dim × 4` for a raw vector, and the graph's internal copy of every point shrinks by the same factor, which is why both storage modes hold less than an unquantized index once past their break-even record count.
+- **Search speed**: an unreranked quantized search is faster than a raw search, and far less accurate. A reranked one matches unquantized recall, is faster below roughly 10,000 records, and is slower above, with the gap widening as the index grows. Measured on real 1536-dimensional embeddings, a reranked quantized search ran at 0.96x the unquantized query time at 10,000 records, 1.56x at 25,000 and 2.42x at 100,000.
+- **Build speed**: a quantized build is faster than an unquantized one, because the graph compares codes rather than vectors.
+- **Accuracy**: see [Quantized search accuracy](#quantized-search-accuracy). Treat quantization as a memory decision that costs accuracy or query time, not as a free win.
 
-Quantization is ideal for production deployments with large vector datasets (100k+ vectors) where memory efficiency is critical.
-
-`"quantized_only"` is recommended for most use cases and maximizes memory savings.
-
-`"quantized_with_raw"` keeps both quantized and raw vectors for exact reconstruction, but uses more memory.
+Quantization pays best on large, high-dimensional datasets where memory is the constraint. Measure recall on your own data before you rely on it.
 
 
 <br/>

--- a/docs/source/vector_database/upgrading.md
+++ b/docs/source/vector_database/upgrading.md
@@ -1,0 +1,58 @@
+# Upgrading from 0.4.x
+
+`zeusdb-vector-database` 0.5.0 changed behaviour in ways an application written against 0.4.x can observe. `zeusdb` 0.1.0 installs it automatically, so read this page before upgrading. Saved indexes and existing code largely keep working; the items below are the differences that matter.
+
+## Search results
+
+**A reranked quantized search returns the raw-vector distance as the score, not the ADC estimate.** Any threshold tuned against the old scores is wrong on a `quantized_with_raw` index. Pass `rerank=0` to restore the ADC scores and ordering.
+
+**Search on a quantized index over-fetches by default.** A `quantized_with_raw` index now fetches and rescores a calibrated number of candidates per query, which holds recall at the level of an unquantized index and costs query time above roughly 10,000 records. See [Product Quantization](product_quantization.md).
+
+## Filters
+
+- An unknown filter operator now raises `ValueError` rather than returning an empty result set.
+- Numbers compare by magnitude across every operator, so an integer and an equal float now match under `eq`, `ne` and `in` as they already did under `lt` and `gte`.
+- Array conditions now compare for equality rather than being silently dropped, so `{"tags": ["ai"]}` matches only records whose `tags` is exactly `["ai"]`.
+- `ne` against a field a record does not have returns false, so a filter for "status is not archived" excludes records with no status at all.
+
+## Add and overwrite
+
+- `add()` with `overwrite=False` on an existing ID reports the collision through the returned `AddResult` rather than raising.
+- Metadata is replaced wholesale on overwrite, never merged, so an overwrite with an empty metadata dict clears it.
+- `summary()` returns a plain ASCII string; the emoji prefix is gone.
+
+## Validation
+
+- Vectors containing `NaN` or an infinity are rejected on `add()`, raise on `search()`, and are refused on `load()`.
+- `m` must be at least 2. `expected_size` must be at most 100,000,000.
+
+## Changed defaults
+
+- The default `m` now scales with `expected_size`: 16 up to 25,000 and 32 above. Pass `m` explicitly to keep the old value.
+- The default `subvectors` now scales with the dimension rather than being fixed at 8, holding compression at 128x from `dim=256` upward. Pass `subvectors: 8` explicitly to keep the old code size.
+- The default `training_size` is derived, 10,000 at the default `bits`, rather than 1,000.
+- The default `ef_search` is `max(2 × top_k, 150)` for `l1` and `l2`; `cosine` keeps `max(2 × top_k, 100)`.
+
+## Removed entry points
+
+Around a dozen entry points that were duplicate, dead or unsafe were removed, including `get_next_id`, which consumed an internal ID on every call. `HNSWIndex` can no longer be constructed directly; instances come from `VectorDatabase.create()` or `load()`. `get_stats()` lost `memory_savings` and gained `graph_memory_mb`, `total_memory_mb` and `raw_vectors_memory_mb`. `get_performance_info()` lost its insertion speedup fields, which described a parallel insert path that does not exist.
+
+## Behaviour improvements you get without code changes
+
+- **Persistence**: loading now reads the saved graph back rather than rebuilding it, so a load takes about a second at 50,000 records and returns identical results to the index that was saved. An index saved by 0.4.x still loads; its graph dump carries the old distance names, so the loader rebuilds it, with no user action required.
+- **Deletion**: removed and overwritten records no longer consume result slots, so `top_k` no longer degrades with churn. A new `compact()` method reclaims the stranded graph nodes.
+- **Concurrency**: concurrent search now works and scales, measured at roughly seven times single-thread throughput at sixteen threads, and `add()` and `search()` can run concurrently.
+
+## Logging
+
+- `ZEUSDB_LOG_FILE` now writes exactly the path given rather than a dated sibling. Set `ZEUSDB_LOG_ROTATION=daily` for the previous behaviour.
+- The disable flag is `ZEUSDB_DISABLE_AUTO_LOGGING` in both the Python and Rust layers, with the former Rust-only name accepted as a deprecated alias. Both require `true`, `1` or `yes`.
+- `warning` and `critical` are not accepted by the Rust layer as `ZEUSDB_LOG_LEVEL` values; use `trace`, `debug`, `info` or `error`.
+
+## Platform support
+
+Wheels are published for Linux x86_64 and aarch64 (glibc and musl), macOS Apple Silicon, and Windows x86_64, for Python 3.10 through 3.14. macOS Intel, 32-bit x86, armv7, s390x and ppc64le are no longer published.
+
+## The `zeusdb` package
+
+`zeusdb` 0.1.0 re-exports the full public surface of the vector database (`VectorDatabase`, `HNSWIndex`, `AddResult`, `init_logging`, `init_file_logging`, `is_logging_initialized`) and provides the `zeusdb.logging_config` helpers the integration packages import. It pins `zeusdb-vector-database>=0.5.0,<0.6.0`, so a future breaking release will not reach you automatically.

--- a/docs/source/vector_database/usage/add.md
+++ b/docs/source/vector_database/usage/add.md
@@ -3,10 +3,11 @@
 Add vectors to your index for similarity search operations.
 
 **HNSWIndex.<span style="color: #663399;">add</span>**(<br/>
-&emsp;&emsp;**data: dict | list[dict] | dict[str, Union[list, np.ndarray]]**<br/>
+&emsp;&emsp;**data: dict | list[dict] | dict[str, Union[list, np.ndarray]]**,<br/>
+&emsp;&emsp;**overwrite: bool = True**<br/>
 ) 
 
-Inserts one or more vectors into the index. 
+Inserts or replaces one or more vectors in the index. 
 
 ZeusDB provides a flexible `.add()` method that supports multiple input formats for inserting or updating vectors in the index. Whether you're adding a single record, a list of documents, or structured arrays, the API is designed to be both intuitive and robust. Each record can include optional metadata for filtering or downstream use.
 
@@ -22,6 +23,9 @@ data : *dict, list[dict], or dict of arrays, required*
 
    See examples below for detailed format specifications.
 
+overwrite : *bool, default True*
+:   Whether an ID already in the index is replaced. With `False`, a colliding record is skipped and counted as an error in the returned `AddResult` rather than raising.
+
 ```
 
 
@@ -32,13 +36,15 @@ data : *dict, list[dict], or dict of arrays, required*
 
 AddResult
 :   Result object containing insertion statistics and error information:
-    * `total_inserted` - Number of vectors successfully inserted or updated
+    * `total_inserted` - Number of vectors successfully inserted or replaced
     * `total_errors` - Number of failed records  
     * `errors` - List of detailed error messages for debugging
-    * `vector_shape` - Shape of the processed vector batch
-    * `summary()` - Human-readable summary string
-    * `is_success()` - Boolean indicating if all records were processed successfully
+    * `vector_shape` - Shape of the processed vector batch, as `(rows, dim)`
+    * `summary()` - One-line plain ASCII summary string of the two counts
+    * `is_success()` - `True` when `total_errors` is zero
 ```
+
+Each format is parsed and validated automatically. Invalid records are skipped rather than aborting the call, and the reason for each is returned in `errors`. A record whose vector contains `NaN` or an infinity is rejected this way.
 
 
 ## Examples
@@ -64,7 +70,7 @@ add_result = index.add({
     "metadata": {"text": "hello"}
 })
 
-print(add_result.summary())     # ✅ 1 inserted, ❌ 0 errors
+print(add_result.summary())     # 1 inserted, 0 errors
 print(add_result.is_success())  # True
 ```
 
@@ -80,7 +86,7 @@ add_result = index.add([
     {"id": "doc2", "values": [0.5, 0.6, 0.7, 0.8], "metadata": {"text": "world"}}
 ])
 
-print(add_result.summary())       # ✅ 2 inserted, ❌ 0 errors
+print(add_result.summary())       # 2 inserted, 0 errors
 print(add_result.vector_shape)    # (2, 4)
 print(add_result.errors)          # []
 ```
@@ -103,8 +109,10 @@ add_result = index.add({
         {"text": "world"}
         ]
 })
-print(add_result)  # AddResult(inserted=2, errors=0, shape=(2, 4))
+print(add_result)  # AddResult(inserted=2, errors=0, shape=Some((2, 4)))
 ```
+
+The `Some(...)` wrapper appears only in the printed form. `add_result.vector_shape` is the plain tuple `(2, 4)`.
 
 <br />
 
@@ -122,7 +130,7 @@ data = [
 
 result = index.add(data)
 
-print(result.summary())   # ✅ 2 inserted, ❌ 0 errors
+print(result.summary())   # 2 inserted, 0 errors
 ```
 
 <br />
@@ -138,17 +146,36 @@ add_result = index.add({
     "embeddings": np.array([[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]], dtype=np.float32),
     "metadatas": [{"text": "hello"}, {"text": "world"}]
 })
-print(add_result)  # AddResult(inserted=2, errors=0, shape=(2, 4))
+print(add_result)  # AddResult(inserted=2, errors=0, shape=Some((2, 4)))
 ```
 
 <br />
 
+## ⚠️ Adding an ID that already exists
 
+`add()` upserts by default. Re-adding an existing ID **replaces the whole record**, metadata included. Metadata is not merged, so a key you leave out of the new record is gone, and an overwrite with an empty metadata dict clears it entirely.
 
+```python
+index = vdb.create(dim=4)
+index.add({"id": "doc1", "values": [0.1, 0.2, 0.3, 0.4], "metadata": {"text": "hello", "lang": "en"}})
 
+# "lang" is not carried over
+index.add({"id": "doc1", "values": [0.3, 0.4, 0.5, 0.6], "metadata": {"text": "goodbye"}})
+print(index.get_records("doc1", return_vector=False))
 
+# overwrite=False rejects the record instead, and counts it as an error
+rejected = index.add({"id": "doc1", "values": [0.5, 0.6, 0.7, 0.8]}, overwrite=False)
+print(rejected.total_inserted, rejected.total_errors)
+print(rejected.errors)
+```
 
+*Output*
+```text
+[{'id': 'doc1', 'metadata': {'text': 'goodbye'}}]
+0 1
+["Vector doc1: ValueError: Vector with ID 'doc1' already exists"]
+```
 
+A rejected record is reported in the `AddResult`. It does not raise. The rejection is also logged at WARNING level, which is visible on stderr under the default development settings.
 
-
-
+Every overwrite leaves a stranded node behind in the graph. `compact()` reclaims them; see [Useful Utilities](../utilities.md).

--- a/docs/source/vector_database/usage/create.md
+++ b/docs/source/vector_database/usage/create.md
@@ -7,7 +7,7 @@ Create a new vector index for similarity search operations.
 &emsp;&emsp;*index_type: str = "hnsw"*,<br/>
 &emsp;&emsp;*dim: int = 1536*,<br/>
 &emsp;&emsp;*space: str = "cosine"*,<br/>
-&emsp;&emsp;*m: int = 16*,<br/>
+&emsp;&emsp;*m: int = 16 or 32, see below*,<br/>
 &emsp;&emsp;*ef_construction: int = 200*,<br/>
 &emsp;&emsp;*expected_size: int = 10000*,<br/>
 &emsp;&emsp;*quantization_config: dict | None = None*<br/>
@@ -24,25 +24,22 @@ index_type : *str, default "hnsw"*
 :   The type of vector index algorithm to create. Currently only supports `"hnsw"` (Hierarchical Navigable Small World). Case-insensitive.
 
 dim : *int, default 1536*
-:   Dimensionality of the vectors to be indexed. All vectors added to this index must have exactly this number of dimensions. The default of 1536 matches OpenAI's text-embedding-ada-002 model output dimensionality.
+:   Dimensionality of the vectors to be indexed. All vectors added to this index must have exactly this number of dimensions. Must be positive. The default of 1536 matches the output dimensionality of OpenAI's `text-embedding-3-small` and `text-embedding-ada-002` models.
 
 space : *str, default "cosine"*
-:   Distance metric used for similarity calculations during search operations. Available options:
-   * `"cosine"` - Cosine similarity (recommended for normalized embeddings)
-   * `"L2"` - Euclidean distance
-   * `"L1"` - Manhattan distance
+:   Distance metric used for similarity calculations during search operations. One of `"cosine"`, `"l1"`, `"l2"`. Case-insensitive.
 
-m : *int, default 16*
-:   Maximum number of bi-directional connections created for each node during graph construction. Higher values improve search recall at the cost of increased memory usage and longer build times. Typical range: 8-64.
+m : *int, default 16 or 32, see below*
+:   Number of bi-directional connections created for each node during graph construction, from 2 to 256. Higher values improve search recall at the cost of increased memory usage and longer build times. The default depends on `expected_size`: 16 for 25,000 or less, 32 above that. Passing `m` explicitly always wins. The minimum is 2 because a graph at `m=1` is degenerate and loses nearly all recall.
 
 ef_construction : *int, default 200*
-:   Size of the dynamic candidate list used during index construction. Larger values result in better index quality but increase build time and memory consumption. Typical range: 100-800.
+:   Size of the dynamic candidate list used during index construction. Must be positive. Larger values result in better index quality but increase build time and memory consumption. Typical range: 100-800.
 
 expected_size : *int, default 10000*
-:   Estimated number of vectors that will be added to the index. Used for pre-allocating internal data structures to optimize performance. This is not a hard limit - you can add more vectors than this estimate.
+:   Estimated number of vectors that will be added to the index, from 1 to 100,000,000. Used for pre-allocating internal data structures and for choosing the default `m`. This is not a hard limit, but `m` is fixed once the index is created, so declare it honestly. An index that grows past twice its declaration logs a warning once, on the `add()` that crosses it.
 
 quantization_config : *dict or None, default None*
-:   Product Quantization configuration for memory-efficient vector compression. When provided, reduces memory footprint at the cost of slight accuracy loss. See the Product Quantization section for detailed configuration options.
+:   Product Quantization configuration for memory-efficient vector compression. Compression costs accuracy unless results are reranked, so read the [Product Quantization](../product_quantization.md) page before enabling it.
 ```
 
 
@@ -52,7 +49,7 @@ quantization_config : *dict or None, default None*
 :class: tip
 
 **HNSWIndex**
-    A configured vector index ready for adding data and performing similarity searches.
+    A configured vector index ready for adding data and performing similarity searches. `HNSWIndex` cannot be constructed directly; instances come from `VectorDatabase.create()` or `VectorDatabase.load()`.
 
 ```
 
@@ -111,12 +108,11 @@ index = vdb.create(
     dim=1536,
     expected_size=50000,
     quantization_config={
-        'type': 'pq',
-        'subvectors': 8,
-        'bits': 8
+        'type': 'pq'
     }
 )
 ```
 
+With only `type` set, the quantization defaults are derived from the index: `subvectors` from the dimension (48 at `dim=1536`, holding compression at 128x), `bits` at 8, `training_size` at 10,000 and `storage_mode` at `quantized_only`. `quantized_only` returns far lower recall than an unquantized index and cannot be reranked, so see [Product Quantization](../product_quantization.md) for how to choose a storage mode.
 
-
+`create()` emits a `UserWarning` when a quantization configuration cannot repay its fixed memory cost at the declared `expected_size`, when `expected_size` is below `training_size` so training would never trigger, when the dimension is too low for quantization to save much, and when a `subvectors` value you passed yourself implies a compression ratio above 50x.

--- a/docs/source/vector_database/usage/search.md
+++ b/docs/source/vector_database/usage/search.md
@@ -4,31 +4,35 @@ Perform similarity search to find the most similar vectors in your index.
 
 **HNSWIndex.<span style="color: #663399;">search</span>**(<br/>
 &emsp;&emsp;**vector: list[float] | list[list[float]] | np.ndarray**,<br/>
-&emsp;&emsp;**filter: dict[str, str] | None = None**,<br/>
+&emsp;&emsp;**filter: dict[str, Any] | None = None**,<br/>
 &emsp;&emsp;**top_k: int = 10**,<br/>
 &emsp;&emsp;**ef_search: int | None = None**,<br/>
-&emsp;&emsp;**return_vector: bool = False**<br/>
+&emsp;&emsp;**return_vector: bool = False**,<br/>
+&emsp;&emsp;**rerank: int | None = None**<br/>
 )
 
-Query the index using a new vector and retrieve the top-k nearest neighbors. Supports both single vector queries and batch searches with multiple vectors. You can also filter by metadata or return the original stored vectors.
+Query the index using a new vector and retrieve the top-k nearest neighbors. Supports both single vector queries and batch searches with multiple vectors. You can also filter by metadata or return the stored vectors.
 
 ```{admonition} Parameters
 :class: note
 
 vector : *list[float], list[list[float]], or np.ndarray, required*
-:   The query vector (single: `list[float]`) or batch of query vectors (`list[list[float]]` or 2D `np.ndarray`) to compare against the index. Must match the index dimension.
+:   The query vector (single: `list[float]` or 1D `np.ndarray`) or batch of query vectors (`list[list[float]]` or 2D `np.ndarray`) to compare against the index. Must match the index dimension and contain only finite values. A query vector containing `NaN` or an infinity raises `ValueError`.
 
-filter : *dict[str, str] or None, default None*
-:   Optional metadata filter. Only vectors with matching key-value metadata pairs will be considered in the search.
+filter : *dict[str, Any] or None, default None*
+:   Optional metadata filter. A field maps either to a plain value, meaning equality, or to a dict of operators. See [Metadata Filtering](../metadata_filtering.md) for the operators and their behaviour.
 
 top_k : *int, default 10*
 :   Number of nearest neighbors to return for each query vector.
 
 ef_search : *int or None, default None*
-:   Search complexity parameter. Higher values improve accuracy at the cost of speed. Defaults to `max(2 × top_k, 100)` when not specified.
+:   Search complexity parameter. Higher values improve accuracy at the cost of speed. The default depends on the distance metric: `max(2 × top_k, 100)` for `cosine` and `max(2 × top_k, 150)` for `l1` and `l2`. It has no effect on a reranked quantized search, where the traversal is widened to the rerank fetch instead; see [Product Quantization](../product_quantization.md).
 
 return_vector : *bool, default False*
-:   If `True`, the result objects will include the original embedding vector. Useful for downstream processing like re-ranking or hybrid search.
+:   If `True`, the result objects will include the stored embedding vector. Under `cosine` this is the normalized form, not the values you supplied. Useful for downstream processing like re-ranking or hybrid search.
+
+rerank : *int or None, default None*
+:   Candidates fetched per requested result before rescoring against raw vectors. Only applies to a quantized index whose `storage_mode` is `quantized_with_raw`; an unquantized or `quantized_only` index ignores it. Omitted, the fetch is calibrated from the index's own data. `rerank=0` turns reranking off and returns ADC scores. See [Product Quantization](../product_quantization.md).
 ```
 
 
@@ -41,15 +45,36 @@ Single Query
 :   Returns `list[dict]` where each dict contains:
     
     * `id` - The vector ID
-    * `score` - Similarity score (lower = more similar)
+    * `score` - Distance (lower = more similar)
     * `metadata` - Associated metadata dictionary
-    * `vector` - Original embedding vector (only if `return_vector=True`)
+    * `vector` - Stored embedding vector (only if `return_vector=True`)
 
 Batch Query
-:   Returns `list[list[dict]]` - a list of result lists, one for each input query vector.
+:   Returns `list[list[dict]]` - a list of result lists, one for each input query vector, in the order the queries were given.
 ```
 
+**The filter is applied after the graph search, not during it.** The index finds the `top_k` nearest vectors first and then discards the ones the filter rejects, so a selective filter can return fewer than `top_k` results, or none at all. Raise `top_k` when you filter.
+
+**On a reranked quantized search the score is the raw-vector distance.** With `rerank=0` it is the ADC estimate. The two are not comparable, so a threshold tuned against one does not carry to the other.
+
 ## Examples
+
+The examples below all run against this index:
+
+```python
+from zeusdb import VectorDatabase
+
+vdb = VectorDatabase()
+index = vdb.create(index_type="hnsw", dim=8)
+index.add([
+    {"id": "doc_001", "values": [0.1, 0.2, 0.3, 0.1, 0.4, 0.2, 0.6, 0.7], "metadata": {"author": "Alice"}},
+    {"id": "doc_002", "values": [0.9, 0.1, 0.4, 0.2, 0.8, 0.5, 0.3, 0.9], "metadata": {"author": "Bob"}},
+    {"id": "doc_003", "values": [0.11, 0.21, 0.31, 0.15, 0.41, 0.22, 0.61, 0.72], "metadata": {"author": "Alice"}},
+    {"id": "doc_004", "values": [0.85, 0.15, 0.42, 0.27, 0.83, 0.52, 0.33, 0.95], "metadata": {"author": "Bob"}},
+    {"id": "doc_005", "values": [0.12, 0.22, 0.33, 0.13, 0.45, 0.23, 0.65, 0.71], "metadata": {"author": "Alice"}},
+])
+query_vector = [0.1, 0.2, 0.3, 0.1, 0.4, 0.2, 0.6, 0.7]
+```
 
 <br />
 
@@ -57,55 +82,51 @@ Batch Query
 
 ```python
 results = index.search(vector=query_vector, top_k=2)
-print(results)
+for res in results:
+    print(res["id"], round(res["score"], 6), res["metadata"])
 ```
 
 *Output*
-```
-[
-  {'id': 'doc_37', 'score': 0.016932480037212372, 'metadata': {'index': '37', 'split': 'test'}}, 
-  {'id': 'doc_33', 'score': 0.019877362996339798, 'metadata': {'split': 'test', 'index': '33'}}
-]
+```text
+doc_001 0.0 {'author': 'Alice'}
+doc_003 0.000988 {'author': 'Alice'}
 ```
 
 <br />
 
 **🔍 Search Example 2 - Query with metadata filter**
 
-This filters on the given metadata after conducting the similarity search.
+The filter is applied to the `top_k` nearest results after the similarity search.
 
 ```python
-query_vector = [0.1, 0.2, 0.3, 0.1, 0.4, 0.2, 0.6, 0.7]
 results = index.search(vector=query_vector, filter={"author": "Alice"}, top_k=5)
-print(results)
+for res in results:
+    print(res["id"], round(res["score"], 6), res["metadata"])
 ```
 
 *Output*
-```
-[
-  {'id': 'doc_001', 'score': 0.0, 'metadata': {'author': 'Alice'}}, 
-  {'id': 'doc_003', 'score': 0.0009883458260446787, 'metadata': {'author': 'Alice'}}, 
-  {'id': 'doc_005', 'score': 0.0011433829786255956, 'metadata': {'author': 'Alice'}}
-]
+```text
+doc_001 0.0 {'author': 'Alice'}
+doc_003 0.000988 {'author': 'Alice'}
+doc_005 0.001143 {'author': 'Alice'}
 ```
 
 <br />
 
 **🔍 Search Example 3 - Search results include vectors**
 
-You can optionally return the stored embedding vectors alongside metadata and similarity scores by setting `return_vector=True`. This is useful when you need access to the raw vectors for downstream tasks such as re-ranking, inspection, or hybrid scoring.
+You can optionally return the stored embedding vectors alongside metadata and similarity scores by setting `return_vector=True`. Under `cosine` the stored vector is normalized to unit length, which is why the values below differ from the ones supplied.
 
 ```python
-results = index.search(vector=query_vector, filter={"split": "test"}, top_k=2, return_vector=True)
-print(results)
+results = index.search(vector=query_vector, top_k=1, return_vector=True)
+print(results[0]["id"], round(results[0]["score"], 6))
+print([round(v, 4) for v in results[0]["vector"]])
 ```
 
 *Output*
-```
-[
-  {'id': 'doc_37', 'score': 0.016932480037212372, 'metadata': {'index': '37', 'split': 'test'}, 'vector': [0.36544516682624817, 0.11984539777040482, 0.7143614292144775, 0.8995016813278198]}, 
-  {'id': 'doc_33', 'score': 0.019877362996339798, 'metadata': {'split': 'test', 'index': '33'}, 'vector': [0.8367619514465332, 0.6394991874694824, 0.9291712641716003, 0.9777664542198181]}
-]
+```text
+doc_001 0.0
+[0.0913, 0.1826, 0.2739, 0.0913, 0.3651, 0.1826, 0.5477, 0.639]
 ```
 
 <br />
@@ -115,21 +136,19 @@ print(results)
 Perform a similarity search on multiple query vectors simultaneously, returning results for each query.
 
 ```python
-query_vector =
-[
-    [0.1, 0.2, 0.3],
-    [0.4, 0.5, 0.6]
+batch = [
+    [0.1, 0.2, 0.3, 0.1, 0.4, 0.2, 0.6, 0.7],
+    [0.9, 0.1, 0.4, 0.2, 0.8, 0.5, 0.3, 0.9],
 ]
-results = index.search(vector=query_vector, top_k=3)
-print(results)
+results = index.search(vector=batch, top_k=2)
+for q, hits in enumerate(results):
+    print(f"query {q}:", [(h["id"], round(h["score"], 6)) for h in hits])
 ```
 
 *Output*
-```
-[
-[{'id': 'a', 'score': 4.999447078546382e-09, 'metadata': {'category': 'A'}}, {'id': 'b', 'score': 0.02536815218627453, 'metadata': {'category': 'B'}}, {'id': 'c', 'score': 0.04058804363012314, 'metadata': {'category': 'A'}}],
-[{'id': 'b', 'score': 4.591760305316939e-09, 'metadata': {'category': 'B'}}, {'id': 'c', 'score': 0.0018091063247993588, 'metadata': {'category': 'A'}}, {'id': 'a', 'score': 0.025368161499500275, 'metadata': {'category': 'A'}}]
-]
+```text
+query 0: [('doc_001', 0.0), ('doc_003', 0.000988)]
+query 1: [('doc_002', 0.0), ('doc_004', 0.002238)]
 ```
 
 <br />
@@ -139,27 +158,35 @@ print(results)
 Perform a similarity search on multiple query vectors from a NumPy array, returning results for each query.
 
 ```python
-query_vector = np.array(
-[
-    [0.1, 0.2, 0.3],
-    [0.7, 0.8, 0.9]
-], dtype=np.float32)
+import numpy as np
 
-results = index.search(vector=query_vector, top_k=3)
-print(results)
+query_batch = np.array(batch, dtype=np.float32)
+
+results = index.search(vector=query_batch, top_k=2)
+for q, hits in enumerate(results):
+    print(f"query {q}:", [h["id"] for h in hits])
+```
+
+*Output*
+```text
+query 0: ['doc_001', 'doc_003']
+query 1: ['doc_002', 'doc_004']
 ```
 
 <br />
 
 **🔍 Search Example 6 - Batch Search with metadata filter**
 
-Performs similarity search on multiple query vectors with metadata filtering, returning filtered results for each query.
+The same filter is applied to every query in the batch. The second query below returns nothing, because both of its two nearest neighbours are Bob's.
 
 ```python
-results = index.search(
-    [[0.1, 0.2, 0.3], [0.7, 0.8, 0.9]],
-    filter={"category": "A"},
-    top_k=3
-)
-print(results)
+results = index.search(batch, filter={"author": "Alice"}, top_k=2)
+for q, hits in enumerate(results):
+    print(f"query {q}:", [h["id"] for h in hits])
+```
+
+*Output*
+```text
+query 0: ['doc_001', 'doc_003']
+query 1: []
 ```

--- a/docs/source/vector_database/utilities.md
+++ b/docs/source/vector_database/utilities.md
@@ -1,8 +1,26 @@
 # Useful Utilities
 
-ZeusDB Vector Database includes a suite of utility functions to help you inspect, manage, and maintain your index. You can view index configuration, attach custom metadata, list stored records, and remove vectors by ID. These tools make it easy to monitor and evolve your index over time,  whether you are experimenting locally or deploying in production.
+ZeusDB Vector Database includes a suite of utility functions to help you inspect, manage, and maintain your index. You can view index configuration, attach custom metadata, list stored records, inspect statistics, remove vectors by ID, and reclaim the space removals leave behind. These tools make it easy to monitor and evolve your index over time, whether you are experimenting locally or deploying in production.
 
 ## Examples
+
+The examples below all run against this index:
+
+```python
+from zeusdb import VectorDatabase
+
+vdb = VectorDatabase()
+index = vdb.create(index_type="hnsw", dim=8, expected_size=5)
+index.add([
+    {"id": "doc_001", "values": [0.1, 0.2, 0.3, 0.1, 0.4, 0.2, 0.6, 0.7], "metadata": {"author": "Alice"}},
+    {"id": "doc_002", "values": [0.9, 0.1, 0.4, 0.2, 0.8, 0.5, 0.3, 0.9], "metadata": {"author": "Bob"}},
+    {"id": "doc_003", "values": [0.11, 0.21, 0.31, 0.15, 0.41, 0.22, 0.61, 0.72], "metadata": {"author": "Alice"}},
+    {"id": "doc_004", "values": [0.85, 0.15, 0.42, 0.27, 0.83, 0.52, 0.33, 0.95], "metadata": {"author": "Bob"}},
+    {"id": "doc_005", "values": [0.12, 0.22, 0.33, 0.13, 0.45, 0.23, 0.65, 0.71], "metadata": {"author": "Alice"}},
+])
+```
+
+<br/>
 
 **Example 1 - Check the details of your HNSW index**
 
@@ -10,40 +28,46 @@ ZeusDB Vector Database includes a suite of utility functions to help you inspect
 print(index.info()) 
 ```
 *Output*
+```text
+HNSWIndex(dim=8, space=cosine, m=16, ef_construction=200, expected_size=5, vectors=5, quantization=none)
 ```
-HNSWIndex(dim=8, space=cosine, m=16, ef_construction=200, expected_size=5, vectors=5)
-```
+
+The `vectors=` field is the live record count, in every storage mode. `get_vector_count()` returns the same number. Other single-value accessors: `index.dim`, `index.get_space()`, `index.contains(id)`, `index.has_quantization()`, `index.can_use_quantization()`, and `VectorDatabase.available_index_types()`.
 
 <br/>
 
 
 **Example 2 - Add index level metadata**
 
+Index level metadata is a flat string-to-string map, separate from the per-record metadata used for filtering. It is preserved by `save()` and `load()`.
+
 ```python
 index.add_metadata({
-  "creator": "John Smith",
-  "version": "0.1",
-  "created_at": "2024-01-28T11:35:55Z",
-  "index_type": "HNSW",
-  "embedding_model": "openai/text-embedding-ada-002",
-  "dataset": "docs_corpus_v2",
-  "environment": "production",
-  "description": "Knowledge base index for customer support articles",
-  "num_documents": "15000",
-  "tags": "['support', 'docs', '2024']"
+    "creator": "John Smith",
+    "version": "0.1",
+    "created_at": "2024-01-28T11:35:55Z",
+    "embedding_model": "openai/text-embedding-ada-002",
+    "environment": "production",
 })
 
 # View index level metadata by key
-print(index.get_metadata("creator"))  
+print(index.get_metadata("creator"))
 
-# View all index level metadata 
-print(index.get_all_metadata())       
+# View all index level metadata
+for key, value in sorted(index.get_all_metadata().items()):
+    print(f"{key}: {value}")
 ```
 *Output*
-```
+```text
 John Smith
-{'description': 'Knowledge base index for customer support articles', 'environment': 'production', 'embedding_model': 'openai/text-embedding-ada-002', 'creator': 'John Smith', 'tags': "['support', 'docs', '2024']", 'num_documents': '15000', 'version': '0.1', 'index_type': 'HNSW', 'dataset': 'docs_corpus_v2', 'created_at': '2024-01-28T11:35:55Z'}
+created_at: 2024-01-28T11:35:55Z
+creator: John Smith
+embedding_model: openai/text-embedding-ada-002
+environment: production
+version: 0.1
 ```
+
+`get_all_metadata()` returns a `dict` whose iteration order is not stable, which is why the example sorts it.
 
 <br/>
 
@@ -51,68 +75,119 @@ John Smith
 **Example 3 - List records in the index**
 
 ```python
-print("\n--- Index Shows first 5 records ---")
-print(index.list(number=5)) # Shows first 5 records
+for record_id, metadata in sorted(index.list(number=5)):
+    print(record_id, metadata)
 ```
 *Output*
+```text
+doc_001 {'author': 'Alice'}
+doc_002 {'author': 'Bob'}
+doc_003 {'author': 'Alice'}
+doc_004 {'author': 'Bob'}
+doc_005 {'author': 'Alice'}
 ```
-[('doc_004', {'author': 'Bob'}), ('doc_003', {'author': 'Alice'}), ('doc_005', {'author': 'Alice'}), ('doc_002', {'author': 'Bob'}), ('doc_001', {'author': 'Alice'})]
-```
+
+`list()` returns `(id, metadata)` tuples in no particular order, so the example sorts them. It is not a paging API: `number` takes the first N in whatever order internal storage yields, and the same N are not guaranteed across calls. It lists every record, in every storage mode.
 
 <br/>
 
 **Example 4 - Remove Records**
 
-ZeusDB allows you to remove a vector and its associated metadata from the index using the .remove_point(id) method. This performs a <u>logical deletion</u>, meaning:
+ZeusDB allows you to remove a vector and its associated metadata from the index using the `.remove_point(id)` method. This performs a <u>logical deletion</u>, meaning:
 - The vector is deleted from internal storage.
 - The metadata is removed.
-- The vector ID is no longer accessible via .contains(), .get_vector(), or .search().
+- The vector ID is no longer returned by `.contains()`, `.get_records()`, or `.search()`.
 
 ```python
-# Remove the point using its ID
-index.remove_point("doc1")  # "doc1" is the unique vector ID
+index.remove_point("doc_001")
 
-print("\n--- Check Removal ---")
-exists = index.contains("doc1")
-print(f"Point 'doc1' {'found' if exists else 'not found'} in index")
+print("doc_001 present:", index.contains("doc_001"))
+print("records remaining:", index.get_vector_count())
 ```
 *Output*
-```
---- Check Removal ---
-Point 'doc1' not found in index
+```text
+doc_001 present: False
+records remaining: 4
 ```
 
-**⚠️ Please Note:** Due to the nature of HNSW, the underlying graph node remains in memory, even after removing a point. This is common for HNSW implementations. To fully remove stale graph entries, consider rebuilding the index.
+**⚠️ Please Note:** Due to the nature of HNSW, the underlying graph node remains in memory after a point is removed. Searches never return it, but it still occupies memory and edge slots. Removed and overwritten records no longer consume result slots, so `top_k` does not degrade with churn, and `compact()` reclaims the stranded nodes.
 
 <br/>
 
-**Example 5 - Retrieve records by ID**
+**Example 5 - Reclaim space left by removals and overwrites**
 
-Use `get_records()` to fetch one or more records by ID, with optional vector inclusion.
+Both `remove_point()` and an overwriting `add()` leave a node behind in the graph. `compact()` rebuilds the graph in memory and returns the number of nodes it reclaimed. Nothing else changes: IDs, metadata, stored vectors, quantized codes and PQ training state all survive, so every ID resolves to the same record before and after.
+
+```python
+print("stranded graph nodes:", index.get_stats()["stranded_graph_nodes"])
+print("reclaimed:", index.compact())
+print("stranded graph nodes:", index.get_stats()["stranded_graph_nodes"])
+```
+*Output*
+```text
+stranded graph nodes: 1
+reclaimed: 1
+stranded graph nodes: 0
+```
+
+`compact()` costs a full rebuild, proportional to the number of live records rather than to the amount of debris, and it holds both graphs in memory while it runs. It returns 0 and does nothing when there is nothing to reclaim. It is never automatic, so schedule it when your workload has accumulated deletions.
+
+<br/>
+
+**Example 6 - Inspect index statistics**
+
+```python
+stats = index.get_stats()
+for key in ["total_vectors", "graph_nodes", "stranded_graph_nodes", "storage_mode_description"]:
+    print(f"{key}: {stats[key]}")
+```
+*Output*
+```text
+total_vectors: 4
+graph_nodes: 4
+stranded_graph_nodes: 0
+storage_mode_description: raw_only
+```
+
+`get_stats()` returns a string-to-string map. It also carries `dimension`, `space`, `m`, `ef_construction`, `expected_size`, `index_type`, `raw_vectors_stored`, `quantized_codes_stored` and `storage_mode`, plus training, compression and rerank calibration fields once quantization is configured.
+
+It is also where the memory figures live, on every index rather than only on a quantized one. `graph_memory_mb` is the HNSW graph, `raw_vectors_memory_mb` is the raw vector store and `total_memory_mb` is the sum of the structures the index holds. `total_memory_mb` is not the resident set: the id maps, the metadata map and the allocator's own overhead sit outside it, at roughly 1,500 bytes per record. Size infrastructure from a measured resident figure rather than the reported one.
+
+<br/>
+
+**Example 7 - Retrieve records by ID**
+
+Use `get_records()` to fetch one or more records by ID. It returns a list of dicts with `id`, `metadata`, and, unless `return_vector=False`, `vector`.
 
 ```python
 # Single record
-print("\n--- Get Single Record ---")
-rec = index.get_records("doc1")
-print(rec)
+print(index.get_records("doc_002", return_vector=False))
 
 # Multiple records
-print("\n--- Get Multiple Records ---")
-batch = index.get_records(["doc1", "doc3"])
-print(batch)
+print(index.get_records(["doc_002", "doc_003"], return_vector=False))
 
-# Metadata only
-print("\n--- Get Metadata only ---")
-meta_only = index.get_records(["doc1", "doc2"], return_vector=False)
-print(meta_only)
+# Missing IDs are silently skipped
+print(index.get_records(["doc_002", "missing_id"], return_vector=False))
 
-# Missing ID silently ignored
-print("\n--- Partial only ---")
-partial = index.get_records(["doc1", "missing_id"])
-print(partial)
+# Vectors are included by default
+record = index.get_records("doc_002")[0]
+print(sorted(record.keys()), len(record["vector"]))
 ```
 
-⚠️ `get_records()` only returns results for IDs that exist in the index. Missing IDs are silently skipped.
+*Output*
+```text
+[{'id': 'doc_002', 'metadata': {'author': 'Bob'}}]
+[{'id': 'doc_002', 'metadata': {'author': 'Bob'}}, {'id': 'doc_003', 'metadata': {'author': 'Alice'}}]
+[{'id': 'doc_002', 'metadata': {'author': 'Bob'}}]
+['id', 'metadata', 'vector'] 8
+```
+
+⚠️ `get_records()` only returns results for IDs that exist in the index. Missing IDs are silently skipped, so a shorter list than you asked for is how a missing ID is reported. Under `cosine` the returned vector is the normalized form, and on a trained `quantized_only` index it is reconstructed from the code rather than stored raw; see [Product Quantization](product_quantization.md).
 
 <br />
 
+## Concurrency
+
+Concurrent search from multiple threads is supported and scales, measured at roughly seven times the single-thread throughput at sixteen threads. `add()` and `search()` can also run concurrently from different threads. `benchmark_concurrent_reads()` measures concurrent search throughput on your own index and data.
+
+<br />

--- a/tests/test_doc_samples.py
+++ b/tests/test_doc_samples.py
@@ -1,0 +1,140 @@
+"""
+Executes the Python code samples on the documentation site.
+
+The site drifted because nothing executed its samples. This suite extracts
+every ```python fence from the core pages under docs/source, runs each page's
+fences top to bottom in one shared namespace, exactly as a reader pasting them
+in order would, and compares what they print against the *Output* block shown
+on the page.
+
+Not executed:
+- fences in a language other than python (bash, text, json)
+- fences preceded by an HTML comment `<!-- zeusdb:skip -->`, used for
+  fragments that depend on import order or process environment
+- logging.md, whose samples configure process-global logging state and only
+  behave as written in a fresh interpreter
+- the two integration guides, which require an OpenAI key and the integration
+  packages
+
+Output comparison is a subsequence match: every non-empty line of the shown
+output must appear in the captured stdout, in order. This tolerates the
+progress lines save() and load() print, which the pages state are omitted.
+"""
+
+import io
+import re
+import warnings
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+DOCS = Path(__file__).resolve().parent.parent / "docs" / "source"
+
+# Pages whose samples are executable as written, in reading order.
+PAGES = [
+    "vector_database/getting_started.md",
+    "vector_database/usage/create.md",
+    "vector_database/usage/add.md",
+    "vector_database/usage/search.md",
+    "vector_database/product_quantization.md",
+    "vector_database/metadata_filtering.md",
+    "vector_database/utilities.md",
+    "vector_database/persistence.md",
+]
+
+SKIP_MARKER = "<!-- zeusdb:skip -->"
+
+# A line that announces the output block that follows the code fence.
+OUTPUT_LABEL = re.compile(r"\*(Output|Results Output:?)[^*]*\*")
+
+
+def extract_blocks(text: str):
+    """Yield (lineno, code, expected_output_or_None) for each python fence."""
+    lines = text.splitlines()
+    i = 0
+    blocks = []
+    while i < len(lines):
+        stripped = lines[i].strip()
+        if stripped.startswith("```python"):
+            skip = any(
+                SKIP_MARKER in lines[j]
+                for j in range(max(0, i - 3), i)
+            )
+            start = i + 1
+            i += 1
+            code_lines = []
+            while i < len(lines) and not lines[i].strip().startswith("```"):
+                code_lines.append(lines[i])
+                i += 1
+            i += 1  # closing fence
+            if skip:
+                continue
+            # Look ahead for an *Output* label and its fence.
+            expected = None
+            j = i
+            seen_label = False
+            while j < len(lines) and j < i + 4:
+                s = lines[j].strip()
+                if not s:
+                    j += 1
+                    continue
+                if not seen_label and OUTPUT_LABEL.search(s):
+                    seen_label = True
+                    j += 1
+                    continue
+                if seen_label and s.startswith("```"):
+                    j += 1
+                    out_lines = []
+                    while j < len(lines) and not lines[j].strip().startswith("```"):
+                        out_lines.append(lines[j])
+                        j += 1
+                    expected = "\n".join(out_lines)
+                break
+            blocks.append((start + 1, "\n".join(code_lines), expected))
+        else:
+            i += 1
+    return blocks
+
+
+def assert_subsequence(expected: str, actual: str, page: str, lineno: int):
+    """Every non-empty expected line appears in the actual output, in order."""
+    actual_lines = [line.rstrip() for line in actual.splitlines()]
+    pos = 0
+    for want in expected.splitlines():
+        want = want.rstrip()
+        if not want:
+            continue
+        try:
+            pos = actual_lines.index(want, pos) + 1
+        except ValueError:
+            pytest.fail(
+                f"{page}:{lineno}: documented output line not produced:\n"
+                f"  expected: {want!r}\n"
+                f"  captured stdout:\n{actual}"
+            )
+
+
+@pytest.mark.parametrize("page", PAGES)
+def test_page_samples_run_and_match_documented_output(page, tmp_path, monkeypatch):
+    """Run a page's samples in order; printed output must match the page."""
+    # .zdb directories and any other artifacts land in the temp directory.
+    monkeypatch.chdir(tmp_path)
+
+    text = (DOCS / page).read_text(encoding="utf-8")
+    blocks = extract_blocks(text)
+    assert blocks, f"{page} has no executable python fences"
+
+    namespace = {"__name__": "__main__"}
+    for lineno, code, expected in blocks:
+        captured = io.StringIO()
+        with warnings.catch_warnings():
+            # create() warns by design on some documented configurations.
+            warnings.simplefilter("ignore")
+            with redirect_stdout(captured):
+                try:
+                    exec(compile(code, f"{page}:{lineno}", "exec"), namespace)
+                except Exception as e:  # noqa: BLE001 - report the sample that broke
+                    pytest.fail(f"{page}:{lineno}: sample raised {type(e).__name__}: {e}")
+        if expected is not None:
+            assert_subsequence(expected, captured.getvalue(), page, lineno)

--- a/tests/test_doc_versions.py
+++ b/tests/test_doc_versions.py
@@ -1,0 +1,305 @@
+"""
+Every version claim on the documentation site against a declared constraint.
+
+The sample suite executes the site's Python fences, so a stale API call fails
+loudly. Version claims are prose and are invisible to it, which is how the
+LangChain page carried an uncapped `langchain-core` floor while the package
+declared `>=0.3.74,<0.4`.
+
+This suite closes that gap. It collects every version constraint written on the
+site and asserts each one is a constraint that `zeusdb`, `zeusdb-vector-database`,
+`langchain-zeusdb` or `llama-index-vector-stores-zeusdb` actually declares.
+
+How references are located, since a regular expression over markdown finds
+recall figures and embedding literals as readily as versions:
+
+- A constraint attached to a package name, such as `zeusdb>=0.0.8`, is matched
+  by name and taken as a claim about that package. Requiring an operator
+  immediately after a known name admits nothing else.
+- A bare constraint, such as `>=2.2.6,<3.0.0`, counts only inside backticks and
+  only when exactly one package is named on the same line. Markdown link
+  targets are stripped first, so a repository URL does not name a second
+  package. Zero names or more than one is a failure asking the author to make
+  the line unambiguous, never a silent skip.
+- Everything else is ignored. `0.000988` in a search result, `lambda_mult=0.7`
+  and `<1ms` in a benchmark table carry no operator and no package name.
+
+Where the truth comes from, given CI has no sibling checkouts:
+
+- `zeusdb` and `zeusdb-vector-database` are installed, so their requirements and
+  their `Requires-Python` are read from distribution metadata.
+- The two integration packages are not installed here and are not dependencies
+  of this one. Their constraints are held in EXPECTED_INTEGRATION_METADATA
+  below, and a separate test reads their `pyproject.toml` from the sibling
+  checkouts and asserts the table matches, skipping when the checkouts are
+  absent. CI therefore enforces the site against the table, and a developer
+  with the checkouts enforces the table against the packages.
+"""
+
+import importlib.metadata
+import re
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs" / "source"
+CONF = DOCS / "conf.py"
+
+# The integration checkouts, siblings of this repository, absent in CI.
+PACKAGES_DIR = ROOT.parents[2]
+SIBLING_PYPROJECTS = {
+    "langchain-zeusdb": (
+        PACKAGES_DIR
+        / "package-langchain-zeusdb"
+        / "repository"
+        / "langchain-zeusdb"
+        / "libs"
+        / "zeusdb"
+        / "pyproject.toml"
+    ),
+    "llama-index-vector-stores-zeusdb": (
+        PACKAGES_DIR
+        / "package-llama-index-vector-stores-zeusdb"
+        / "repository"
+        / "llama-index-vector-stores-zeusdb"
+        / "pyproject.toml"
+    ),
+}
+
+# What the two integration packages declare. Checked against the sibling
+# checkouts by test_the_expected_integration_metadata_matches_the_checkouts.
+EXPECTED_INTEGRATION_METADATA = {
+    "langchain-zeusdb": {
+        "python": ">=3.10",
+        "zeusdb": ">=0.0.8",
+        "langchain-core": ">=0.3.74,<0.4",
+    },
+    "llama-index-vector-stores-zeusdb": {
+        "python": ">=3.10,<4.0",
+        "zeusdb": ">=0.0.8",
+        "llama-index-core": ">=0.14.6",
+    },
+}
+
+# Longest first, so `zeusdb-vector-database` is not tokenised as `zeusdb`.
+KNOWN_NAMES = [
+    "llama-index-vector-stores-zeusdb",
+    "zeusdb-vector-database",
+    "llama-index-core",
+    "langchain-zeusdb",
+    "langchain-core",
+    "zeusdb",
+    "numpy",
+    "python",
+]
+
+_CLAUSE = r"[<>!~=]=?\s*[0-9][0-9A-Za-z.*+!]*"
+_SPEC = rf"(?:{_CLAUSE})(?:\s*,\s*{_CLAUSE})*"
+
+NAME_RE = re.compile(r"\b(" + "|".join(re.escape(n) for n in KNOWN_NAMES) + r")\b", re.I)
+ANCHORED_RE = re.compile(
+    r"\b(" + "|".join(re.escape(n) for n in KNOWN_NAMES) + rf")\s*({_SPEC})", re.I
+)
+BACKTICKED_RE = re.compile(rf"`({_SPEC})`")
+SERIES_RE = re.compile(r"\b(\d+\.\d+)\.x\b")
+PY_MINOR_RE = re.compile(r"\b3\.(\d+)\b")
+LINK_TARGET_RE = re.compile(r"\]\([^)]*\)")
+
+
+def canonical(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).strip().lower()
+
+
+def markdown_pages():
+    return sorted(DOCS.rglob("*.md"))
+
+
+def declared_constraints() -> dict[str, list[SpecifierSet]]:
+    """Every constraint the four packages declare, keyed by canonical name."""
+    declared: dict[str, list[SpecifierSet]] = {}
+
+    def record(name: str, spec: str) -> None:
+        specifier = SpecifierSet(spec)
+        bucket = declared.setdefault(canonical(name), [])
+        if specifier not in bucket:
+            bucket.append(specifier)
+
+    for distribution in ("zeusdb", "zeusdb-vector-database"):
+        try:
+            metadata = importlib.metadata.metadata(distribution)
+        except importlib.metadata.PackageNotFoundError:
+            pytest.fail(
+                f"{distribution} is not installed, so its declared constraints "
+                f"cannot be read. Install this package first, for example "
+                f"`uv pip install -e .`."
+            )
+        requires_python = metadata.get("Requires-Python")
+        if requires_python:
+            record("python", requires_python)
+        for entry in importlib.metadata.requires(distribution) or []:
+            requirement = Requirement(entry)
+            # Extras are not what a plain install resolves, so they are not
+            # constraints the site may quote.
+            if requirement.marker is None and str(requirement.specifier):
+                record(requirement.name, str(requirement.specifier))
+
+    for declarations in EXPECTED_INTEGRATION_METADATA.values():
+        for name, spec in declarations.items():
+            record(name, spec)
+
+    return declared
+
+
+def claims_on(line: str):
+    """Yield (package, specifier_text) for every version claim on one line."""
+    stripped = LINK_TARGET_RE.sub("]", line)
+
+    consumed: list[tuple[int, int]] = []
+    for match in ANCHORED_RE.finditer(stripped):
+        consumed.append(match.span(2))
+        yield canonical(match.group(1)), match.group(2)
+
+    bare = [
+        match
+        for match in BACKTICKED_RE.finditer(stripped)
+        if not any(start <= match.start(1) and match.end(1) <= end for start, end in consumed)
+    ]
+    series = list(SERIES_RE.finditer(stripped))
+    if not bare and not series:
+        return
+
+    names = {canonical(match.group(1)) for match in NAME_RE.finditer(stripped)}
+    if bare and len(names) != 1:
+        pytest.fail(
+            f"a version constraint is written on a line naming {sorted(names) or 'no package'}, "
+            f"so it cannot be attributed. Name exactly one package on the line, or "
+            f"attach the constraint to its name.\n  {line.strip()}"
+        )
+    if len(names) != 1:
+        # A series written without a package on the line, such as the heading
+        # "Upgrading from 0.4.x", takes its subject from the page rather than
+        # the line. It is not a constraint and is left alone.
+        return
+    name = names.pop()
+    for match in bare:
+        yield name, match.group(1)
+    for match in series:
+        # A `0.5.x` series claim is satisfied when the declared constraint
+        # admits the first release of that series.
+        yield name, f"=={match.group(1)}.0"
+
+
+def test_every_constraint_on_the_site_is_one_a_package_declares():
+    """A version claim is correct only if some package declares it.
+
+    This is the check that would have caught `langchain-core: 0.3.74 or
+    higher`, written while `langchain-zeusdb` declared `>=0.3.74,<0.4`.
+    """
+    declared = declared_constraints()
+    wrong = []
+    checked = 0
+
+    for page in markdown_pages():
+        for number, line in enumerate(page.read_text(encoding="utf-8").splitlines(), 1):
+            for name, spec in claims_on(line):
+                checked += 1
+                known = declared.get(name)
+                if known is None:
+                    wrong.append(
+                        f"{page.relative_to(ROOT)}:{number} names {name}, which none "
+                        f"of the four packages depends on"
+                    )
+                    continue
+                if spec.startswith("=="):
+                    # A series claim, checked by containment rather than equality.
+                    if not any(
+                        constraint.contains(Version(spec[2:]), prereleases=True)
+                        for constraint in known
+                    ):
+                        wrong.append(
+                            f"{page.relative_to(ROOT)}:{number} claims {name} {spec[2:]}, "
+                            f"outside {[str(c) for c in known]}"
+                        )
+                    continue
+                if SpecifierSet(spec) not in known:
+                    wrong.append(
+                        f"{page.relative_to(ROOT)}:{number} states {name} {spec}, "
+                        f"declared as {[str(c) for c in known]}"
+                    )
+
+    assert checked, "no version constraints were found, so this test proves nothing"
+    assert not wrong, "version claims that no package declares:\n" + "\n".join(wrong)
+
+
+def test_every_python_version_named_on_the_site_is_supported():
+    """A minor named next to the word Python must be one the package claims."""
+    supported = {
+        classifier.rsplit(" :: ", 1)[1]
+        for classifier in importlib.metadata.metadata("zeusdb").get_all("Classifier") or []
+        if classifier.startswith("Programming Language :: Python :: 3.")
+    }
+    assert supported, "zeusdb declares no per-minor Python classifiers"
+
+    wrong = []
+    for page in markdown_pages():
+        for number, line in enumerate(page.read_text(encoding="utf-8").splitlines(), 1):
+            if not re.search(r"\bpython\b", line, re.I):
+                continue
+            for match in PY_MINOR_RE.finditer(line):
+                if match.group(0) not in supported:
+                    wrong.append(
+                        f"{page.relative_to(ROOT)}:{number} names Python "
+                        f"{match.group(0)}, which is not a supported minor "
+                        f"{sorted(supported)}"
+                    )
+
+    assert not wrong, "unsupported Python versions on the site:\n" + "\n".join(wrong)
+
+
+def test_the_documented_release_is_the_installed_version():
+    """`conf.py` sets the version the theme renders, and it drifted before."""
+    match = re.search(r"^release\s*=\s*['\"]([^'\"]+)['\"]", CONF.read_text(encoding="utf-8"), re.M)
+    assert match, "conf.py declares no release"
+    assert Version(match.group(1)) == Version(importlib.metadata.version("zeusdb"))
+
+
+@pytest.mark.parametrize("package", sorted(EXPECTED_INTEGRATION_METADATA))
+def test_the_expected_integration_metadata_matches_the_checkouts(package):
+    """The table above against the packages it stands in for.
+
+    Skips in CI, which has no sibling checkouts. Locally this is what keeps the
+    table from going stale behind the site.
+    """
+    pyproject = SIBLING_PYPROJECTS[package]
+    if not pyproject.is_file():
+        pytest.skip(f"{package} is not checked out at {pyproject}")
+
+    text = pyproject.read_text(encoding="utf-8")
+    block = re.search(r"^dependencies\s*=\s*\[(.*?)^\]", text, re.S | re.M)
+    assert block, f"{package} declares no top level dependencies list"
+    actual = {}
+    for entry in re.findall(r"[\"']([^\"']+)[\"']", block.group(1)):
+        requirement = Requirement(entry)
+        actual[canonical(requirement.name)] = requirement.specifier
+
+    requires_python = re.search(
+        r"^requires-python\s*=\s*[\"']([^\"']+)[\"']", text, re.M
+    )
+    assert requires_python, f"{package} declares no requires-python"
+    actual["python"] = SpecifierSet(requires_python.group(1))
+
+    expected = {
+        canonical(name): SpecifierSet(spec)
+        for name, spec in EXPECTED_INTEGRATION_METADATA[package].items()
+    }
+    for name, specifier in expected.items():
+        assert name in actual, f"{package} no longer declares {name}"
+        assert actual[name] == specifier, (
+            f"{package} declares {name}{actual[name]}, while "
+            f"EXPECTED_INTEGRATION_METADATA and the site say {name}{specifier}. "
+            f"Update the table and the site together."
+        )


### PR DESCRIPTION
- Correct the product quantization recall and compression, the rerank argument, get_stats keys, summary output, persistence, logging, metadata filtering and the search and add surfaces.
- Add docs/source/vector_database/upgrading.md, describing what changed between 0.4.x and 0.5.0.
- Correct the LangChain Core constraint on the LangChain integration page, which stated a floor of 0.3.74 while langchain-zeusdb declares langchain-core>=0.3.74,<0.4.
- Remove the LangChain Versions subsection, which restated that constraint with the same missing cap.
- State the Requirements block on both integration pages as the constraints the packages declare.
- Set the documented release to 0.1.0.
- Add tests/test_doc_samples.py, executing every Python fence on the core pages and comparing what they print against the output shown.
- Add tests/test_doc_versions.py, asserting every version constraint on the site is one that zeusdb, zeusdb-vector-database, langchain-zeusdb or llama-index-vector-stores-zeusdb declares.